### PR TITLE
v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Responses for `POST /api/v3/order/cancelReplace` support all 4 Response Types
 - Support for specifying `recvWindow` via `WithRecvWindow()` function
 - `strategyId` and `strategyType` parameters added to `TestNewOrder` and `CreateOrderService` endpoints
-- 'UiKlines': change `interval` to `limit`
+- `UiKlines`: corrected `limit` parameter to not be sent as` interval`
 
 ## v0.2.0 - 2023-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Responses for `POST /api/v3/order/cancelReplace` support all 4 Response Types
 - Support for specifying `recvWindow` via `WithRecvWindow()` function
 - `strategyId` and `strategyType` parameters added to `TestNewOrder` and `CreateOrderService` endpoints
-- `UiKlines`: corrected `limit` parameter to not be sent as` interval`
+- `UiKlines`: corrected `limit` parameter to not be sent as `interval`
 
 ## v0.2.0 - 2023-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Responses for `POST /api/v3/order/cancelReplace` support all 4 Response Types
 - Support for specifying `recvWindow` via `WithRecvWindow()` function
 - `strategyId` and `strategyType` parameters added to `TestNewOrder` and `CreateOrderService` endpoints
+- 'UiKlines': change `interval` to `limit`
 
 ## v0.2.0 - 2023-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change log
 
+## v0.3.0 - 2023-05-02
+
+### Added
+- New Endpoint, `NewGetManagedSubAccountDepositAddressService()`: `GET /sapi/v1/managed-subaccount/deposit/address` - Get Managed Sub-account Deposit Address (For Investor Master Account) (USER_DATA)
+
+### Fixed
+- Added separate USDT-M and COIN-M Response Types for relevant Subaccount Endpoints
+- Added support for Conditional Fields in relevant responses on Account Endpoints
+- Responses for `POST /api/v3/order/cancelReplace` support all 4 Response Types
+- Support for specifying `recvWindow` via `WithRecvWindow()` function
+- `strategyId` and `strategyType` parameters added to `TestNewOrder` and `CreateOrderService` endpoints
+
 ## v0.2.0 - 2023-04-21
 
 ### Added

--- a/account.go
+++ b/account.go
@@ -18,6 +18,7 @@ type TestNewOrder struct {
 	price               *float64
 	newClientOrderId    *string
 	strategyId          *int
+	strategyType        *int
 	stopPrice           *float64
 	trailingDelta       *int
 	icebergQty          *float64
@@ -79,6 +80,12 @@ func (s *TestNewOrder) StrategyId(strategyId int) *TestNewOrder {
 	return s
 }
 
+// StrategyType set strategyType
+func (s *TestNewOrder) StrategyType(strategyType int) *TestNewOrder {
+	s.strategyType = &strategyType
+	return s
+}
+
 // StopPrice set stopPrice
 func (s *TestNewOrder) StopPrice(stopPrice float64) *TestNewOrder {
 	s.stopPrice = &stopPrice
@@ -137,6 +144,9 @@ func (s *TestNewOrder) Do(ctx context.Context, opts ...RequestOption) (res *Acco
 	if s.strategyId != nil {
 		r.setParam("strategyId", *s.strategyId)
 	}
+	if s.strategyType != nil {
+		r.setParam("strategyType", *s.strategyType)
+	}
 	if s.stopPrice != nil {
 		r.setParam("stopPrice", *s.stopPrice)
 	}
@@ -181,6 +191,7 @@ type CreateOrderService struct {
 	price                   *float64
 	newClientOrderId        *string
 	strategyId              *int
+	strategyType            *int
 	stopPrice               *float64
 	trailingDelta           *int
 	icebergQty              *float64
@@ -236,6 +247,18 @@ func (s *CreateOrderService) NewClientOrderId(newClientOrderId string) *CreateOr
 	return s
 }
 
+// StrategyId set strategyId
+func (s *CreateOrderService) StrategyId(strategyId int) *CreateOrderService {
+	s.strategyId = &strategyId
+	return s
+}
+
+// StrategyType set strategyType
+func (s *CreateOrderService) StrategyType(strategyType int) *CreateOrderService {
+	s.strategyType = &strategyType
+	return s
+}
+
 // StopPrice set stopPrice
 func (s *CreateOrderService) StopPrice(stopPrice float64) *CreateOrderService {
 	s.stopPrice = &stopPrice
@@ -254,7 +277,7 @@ func (s *CreateOrderService) IcebergQuantity(icebergQty float64) *CreateOrderSer
 	return s
 }
 
-// NewOrderRespType set icebergQuantity
+// NewOrderRespType set newOrderRespType
 func (s *CreateOrderService) NewOrderRespType(newOrderRespType string) *CreateOrderService {
 	s.newOrderRespType = &newOrderRespType
 	return s
@@ -306,6 +329,9 @@ func (s *CreateOrderService) Do(ctx context.Context, opts ...RequestOption) (res
 	}
 	if s.strategyId != nil {
 		r.setParam("strategyId", *s.strategyId)
+	}
+	if s.strategyType != nil {
+		r.setParam("strategyType", *s.strategyType)
 	}
 	if s.stopPrice != nil {
 		r.setParam("stopPrice", *s.stopPrice)
@@ -376,6 +402,14 @@ type CreateOrderResponseRESULT struct {
 	Side                    string `json:"side"`
 	WorkingTime             uint64 `json:"workingTime"`
 	SelfTradePreventionMode string `json:"selfTradePreventionMode"`
+	IcebergQty              string `json:"icebergQty,omitempty"`
+	PreventedMatchId        int64  `json:"preventedMatchId,omitempty"`
+	PreventedQuantity       string `json:"preventedQuantity,omitempty"`
+	StopPrice               string `json:"stopPrice,omitempty"`
+	StrategyId              int64  `json:"strategyId,omitempty"`
+	StrategyType            int64  `json:"strategyType,omitempty"`
+	TrailingDelta           string `json:"trailingDelta,omitempty"`
+	TrailingTime            int64  `json:"trailingTime,omitempty"`
 }
 
 // Create CreateOrderResponseFULL
@@ -395,6 +429,14 @@ type CreateOrderResponseFULL struct {
 	Side                    string `json:"side"`
 	WorkingTime             uint64 `json:"workingTime"`
 	SelfTradePreventionMode string `json:"selfTradePreventionMode"`
+	IcebergQty              string `json:"icebergQty,omitempty"`
+	PreventedMatchId        int64  `json:"preventedMatchId,omitempty"`
+	PreventedQuantity       string `json:"preventedQuantity,omitempty"`
+	StopPrice               string `json:"stopPrice,omitempty"`
+	StrategyId              int64  `json:"strategyId,omitempty"`
+	StrategyType            int64  `json:"strategyType,omitempty"`
+	TrailingDelta           string `json:"trailingDelta,omitempty"`
+	TrailingTime            int64  `json:"trailingTime,omitempty"`
 	Fills                   []struct {
 		Price           string `json:"price"`
 		Qty             string `json:"qty"`
@@ -532,6 +574,14 @@ type CancelOrderResponse struct {
 	Type                string `json:"type"`
 	Side                string `json:"side"`
 	SelfTradePrevention string `json:"selfTradePrevention"`
+	IcebergQty          string `json:"icebergQty,omitempty"`
+	PreventedMatchId    int64  `json:"preventedMatchId,omitempty"`
+	PreventedQuantity   string `json:"preventedQuantity,omitempty"`
+	StopPrice           string `json:"stopPrice,omitempty"`
+	StrategyId          int64  `json:"strategyId,omitempty"`
+	StrategyType        int64  `json:"strategyType,omitempty"`
+	TrailingDelta       string `json:"trailingDelta,omitempty"`
+	TrailingTime        int64  `json:"trailingTime,omitempty"`
 }
 
 // Query Order (USER_DATA)
@@ -606,15 +656,19 @@ type GetOrderResponse struct {
 	Type                    string `json:"type"`
 	Side                    string `json:"side"`
 	StopPrice               string `json:"stopPrice"`
-	IcebergQty              string `json:"icebergQty"`
+	IcebergQty              string `json:"icebergQty,omitempty"`
 	Time                    uint64 `json:"time"`
 	UpdateTime              uint64 `json:"updateTime"`
 	IsWorking               bool   `json:"isWorking"`
 	WorkingTime             uint64 `json:"workingTime"`
 	OrigQuoteOrderQty       string `json:"origQuoteOrderQty"`
 	SelfTradePreventionMode string `json:"selfTradePreventionMode"`
-	PreventedMatchId        string `json:"preventedMatchId"`
-	PreventedQuantity       string `json:"preventedQuantity"`
+	PreventedMatchId        int64  `json:"preventedMatchId,omitempty"`
+	PreventedQuantity       string `json:"preventedQuantity,omitempty"`
+	StrategyId              int64  `json:"strategyId,omitempty"`
+	StrategyType            int64  `json:"strategyType,omitempty"`
+	TrailingDelta           string `json:"trailingDelta,omitempty"`
+	TrailingTime            int64  `json:"trailingTime,omitempty"`
 }
 
 // Cancel an Existing Order and Send a New Order (TRADE)
@@ -824,55 +878,98 @@ func (s *CancelReplaceService) Do(ctx context.Context, opts ...RequestOption) (r
 		m["cancelRestrictions"] = *s.cancelRestrictions
 	}
 	r.setParams(m)
-	data, err := s.c.callAPI(ctx, r, opts...)
-	if err != nil {
-		return nil, err
-	}
+	data, _ := s.c.callAPI(ctx, r, opts...)
 	res = new(CancelReplaceResponse)
 	err = json.Unmarshal(data, res)
 	if err != nil {
 		return nil, err
 	}
-	return res, nil
+	return res, err
 }
 
-// Create CancelReplaceResponse
 type CancelReplaceResponse struct {
-	CancelResult   string `json:"cancelResult"`
-	NewOrderResult string `json:"newOrderResult"`
-	CancelResponse struct {
-		Symbol                  string `json:"symbol"`
-		OrigClientOrderId       string `json:"origClientOrderId"`
-		OrderId                 int64  `json:"orderId"`
-		OrderListId             int64  `json:"orderListId"`
-		ClientOrderId           string `json:"clientOrderId"`
-		Price                   string `json:"price"`
-		OrigQty                 string `json:"origQty"`
-		ExecutedQty             string `json:"executedQty"`
-		CumulativeQuoteQty      string `json:"cumulativeQuoteQty"`
-		Status                  string `json:"status"`
-		TimeInForce             string `json:"timeInForce"`
-		Type                    string `json:"type"`
-		Side                    string `json:"side"`
-		SelfTradePreventionMode string `json:"selfTradePreventionMode"`
-	} `json:"cancelResponse"`
-	NewOrderResponse struct {
-		Symbol                  string   `json:"symbol"`
-		OrderId                 int64    `json:"orderId"`
-		OrderListId             int64    `json:"orderListId"`
-		ClientOrderId           string   `json:"clientOrderId"`
-		TransactTime            uint64   `json:"transactTime"`
-		Price                   string   `json:"price"`
-		OrigQty                 string   `json:"origQty"`
-		ExecutedQty             string   `json:"executedQty"`
-		CumulativeQuoteQty      string   `json:"cumulativeQuoteQty"`
-		Status                  string   `json:"status"`
-		TimeInForce             string   `json:"timeInForce"`
-		Type                    string   `json:"type"`
-		Side                    string   `json:"side"`
-		Fills                   []string `json:"fills"`
-		SelfTradePreventionMode string   `json:"selfTradePreventionMode"`
-	} `json:"newOrderResponse"`
+	Code           int64  `json:"code,omitempty"`
+	Msg            string `json:"msg,omitempty"`
+	CancelResult   string `json:"cancelResult,omitempty"`
+	NewOrderResult string `json:"newOrderResult,omitempty"`
+	CancelResponse *struct {
+		Code                    int    `json:"code,omitempty"`
+		Msg                     string `json:"msg,omitempty"`
+		Symbol                  string `json:"symbol,omitempty"`
+		OrigClientOrderId       string `json:"origClientOrderId,omitempty"`
+		OrderId                 int64  `json:"orderId,omitempty"`
+		OrderListId             int64  `json:"orderListId,omitempty"`
+		ClientOrderId           string `json:"clientOrderId,omitempty"`
+		Price                   string `json:"price,omitempty"`
+		OrigQty                 string `json:"origQty,omitempty"`
+		ExecutedQty             string `json:"executedQty,omitempty"`
+		CumulativeQuoteQty      string `json:"cumulativeQuoteQty,omitempty"`
+		Status                  string `json:"status,omitempty"`
+		TimeInForce             string `json:"timeInForce,omitempty"`
+		Type                    string `json:"type,omitempty"`
+		Side                    string `json:"side,omitempty"`
+		SelfTradePreventionMode string `json:"selfTradePreventionMode,omitempty"`
+	} `json:"cancelResponse,omitempty"`
+	NewOrderResponse *struct {
+		Code                    int64    `json:"code,omitempty"`
+		Msg                     string   `json:"msg,omitempty"`
+		Symbol                  string   `json:"symbol,omitempty"`
+		OrderId                 int64    `json:"orderId,omitempty"`
+		OrderListId             int64    `json:"orderListId,omitempty"`
+		ClientOrderId           string   `json:"clientOrderId,omitempty"`
+		TransactTime            uint64   `json:"transactTime,omitempty"`
+		Price                   string   `json:"price,omitempty"`
+		OrigQty                 string   `json:"origQty,omitempty"`
+		ExecutedQty             string   `json:"executedQty,omitempty"`
+		CumulativeQuoteQty      string   `json:"cumulativeQuoteQty,omitempty"`
+		Status                  string   `json:"status,omitempty"`
+		TimeInForce             string   `json:"timeInForce,omitempty"`
+		Type                    string   `json:"type,omitempty"`
+		Side                    string   `json:"side,omitempty"`
+		Fills                   []string `json:"fills,omitempty"`
+		SelfTradePreventionMode string   `json:"selfTradePreventionMode,omitempty"`
+	} `json:"newOrderResponse,omitempty"`
+	Data *struct {
+		CancelResult   string `json:"cancelResult,omitempty"`
+		NewOrderResult string `json:"newOrderResult,omitempty"`
+		CancelResponse *struct {
+			Code                    int64  `json:"code,omitempty"`
+			Msg                     string `json:"msg,omitempty"`
+			Symbol                  string `json:"symbol,omitempty"`
+			OrigClientOrderId       string `json:"origClientOrderId,omitempty"`
+			OrderId                 int64  `json:"orderId,omitempty"`
+			OrderListId             int64  `json:"orderListId,omitempty"`
+			ClientOrderId           string `json:"clientOrderId,omitempty"`
+			Price                   string `json:"price,omitempty"`
+			OrigQty                 string `json:"origQty,omitempty"`
+			ExecutedQty             string `json:"executedQty,omitempty"`
+			CumulativeQuoteQty      string `json:"cumulativeQuoteQty,omitempty"`
+			Status                  string `json:"status,omitempty"`
+			TimeInForce             string `json:"timeInForce,omitempty"`
+			Type                    string `json:"type,omitempty"`
+			Side                    string `json:"side,omitempty"`
+			SelfTradePreventionMode string `json:"selfTradePreventionMode,omitempty"`
+		} `json:"cancelResponse,omitempty"`
+		NewOrderResponse struct {
+			Code                    int64    `json:"code,omitempty"`
+			Msg                     string   `json:"msg,omitempty"`
+			Symbol                  string   `json:"symbol,omitempty"`
+			OrderId                 int64    `json:"orderId,omitempty"`
+			OrderListId             int64    `json:"orderListId,omitempty"`
+			ClientOrderId           string   `json:"clientOrderId,omitempty"`
+			TransactTime            uint64   `json:"transactTime,omitempty"`
+			Price                   string   `json:"price,omitempty"`
+			OrigQty                 string   `json:"origQty,omitempty"`
+			ExecutedQty             string   `json:"executedQty,omitempty"`
+			CumulativeQuoteQty      string   `json:"cumulativeQuoteQty,omitempty"`
+			Status                  string   `json:"status,omitempty"`
+			TimeInForce             string   `json:"timeInForce,omitempty"`
+			Type                    string   `json:"type,omitempty"`
+			Side                    string   `json:"side,omitempty"`
+			Fills                   []string `json:"fills,omitempty"`
+			SelfTradePreventionMode string   `json:"selfTradePreventionMode,omitempty"`
+		} `json:"newOrderResponse"`
+	} `json:"data,omitempty"`
 }
 
 // Binance Get current open orders (GET /api/v3/openOrders)
@@ -925,13 +1022,19 @@ type NewOpenOrdersResponse struct {
 	Type                    string `json:"type"`
 	Side                    string `json:"side"`
 	StopPrice               string `json:"stopPrice"`
-	IcebergQty              string `json:"icebergQty"`
+	IcebergQty              string `json:"icebergQty,omitempty"`
 	Time                    uint64 `json:"time"`
 	UpdateTime              uint64 `json:"updateTime"`
 	IsWorking               bool   `json:"isWorking"`
 	WorkingTime             uint64 `json:"workingTime"`
 	OrigQuoteOrderQty       string `json:"origQuoteOrderQty"`
 	SelfTradePreventionMode string `json:"selfTradePreventionMode"`
+	PreventedMatchId        int64  `json:"preventedMatchId,omitempty"`
+	PreventedQuantity       string `json:"preventedQuantity,omitempty"`
+	StrategyId              int64  `json:"strategyId,omitempty"`
+	StrategyType            int64  `json:"strategyType,omitempty"`
+	TrailingDelta           string `json:"trailingDelta,omitempty"`
+	TrailingTime            int64  `json:"trailingTime,omitempty"`
 }
 
 // Binance Get all account orders; active, canceled, or filled (GET /api/v3/allOrders)
@@ -1026,15 +1129,19 @@ type NewAllOrdersResponse struct {
 	Type                    string `json:"type"`
 	Side                    string `json:"side"`
 	StopPrice               string `json:"stopPrice"`
-	IcebergQty              string `json:"icebergQty"`
+	IcebergQty              string `json:"icebergQty,omitempty"`
 	Time                    uint64 `json:"time"`
 	UpdateTime              uint64 `json:"updateTime"`
 	IsWorking               bool   `json:"isWorking"`
 	OrigQuoteOrderQty       string `json:"origQuoteOrderQty"`
 	WorkingTime             uint64 `json:"workingTime"`
 	SelfTradePreventionMode string `json:"selfTradePreventionMode"`
-	PreventedMatchId        int64  `json:"preventedMatchId"`
-	PreventedQuantity       string `json:"preventedQuantity"`
+	PreventedMatchId        int64  `json:"preventedMatchId,omitempty"`
+	PreventedQuantity       string `json:"preventedQuantity,omitempty"`
+	StrategyId              int64  `json:"strategyId,omitempty"`
+	StrategyType            int64  `json:"strategyType,omitempty"`
+	TrailingDelta           string `json:"trailingDelta,omitempty"`
+	TrailingTime            int64  `json:"trailingTime,omitempty"`
 }
 
 // Binance New OCO (TRADE) (POST /api/v3/order/oco)
@@ -1275,6 +1382,13 @@ type OrderOCOResponse struct {
 		StopPrice               string  `json:"stopPrice"`
 		WorkingTime             uint64  `json:"workingTime"`
 		SelfTradePreventionMode string  `json:"selfTradePreventionMode"`
+		IcebergQty              string  `json:"icebergQty,omitempty"`
+		PreventedMatchId        int64   `json:"preventedMatchId,omitempty"`
+		PreventedQuantity       string  `json:"preventedQuantity,omitempty"`
+		StrategyId              int64   `json:"strategyId,omitempty"`
+		StrategyType            int64   `json:"strategyType,omitempty"`
+		TrailingDelta           string  `json:"trailingDelta,omitempty"`
+		TrailingTime            int64   `json:"trailingTime,omitempty"`
 	} `json:"orderReports"`
 }
 
@@ -1424,7 +1538,7 @@ func (s *QueryAllOCOService) Limit(limit int) *QueryAllOCOService {
 }
 
 // Do send request
-func (s *QueryAllOCOService) Do(ctx context.Context, opts ...RequestOption) (res *OCOResponse, err error) {
+func (s *QueryAllOCOService) Do(ctx context.Context, opts ...RequestOption) (res []*OCOResponse, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: "/api/v3/allOrderList",
@@ -1444,12 +1558,12 @@ func (s *QueryAllOCOService) Do(ctx context.Context, opts ...RequestOption) (res
 	}
 	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
-		return nil, err
+		return []*OCOResponse{}, err
 	}
-	res = new(OCOResponse)
-	err = json.Unmarshal(data, res)
+	res = make([]*OCOResponse, 0)
+	err = json.Unmarshal(data, &res)
 	if err != nil {
-		return nil, err
+		return []*OCOResponse{}, err
 	}
 	return res, nil
 }

--- a/account_test.go
+++ b/account_test.go
@@ -453,68 +453,91 @@ func (s *accountTestSuite) TestQueryOCOService() {
 }
 
 func (s *accountTestSuite) TestQueryAllOCOService() {
-	data := []byte(`{
-		"orderListId": 123456,
-		"contingencyType": "OCO",
-		"listStatusType": "EXEC_STARTED",
-		"listOrderStatus": "EXECUTING",
-		"listClientOrderId": "myListClientOrderId",
-		"transactionTime": 1616976140402,
-		"symbol": "BTCUSDT",
-		"orders": [
-			{
-				"symbol": "BTCUSDT",
-				"orderId": 654321,
-				"clientOrderId": "myClientOrderId"
-			}
-		]
-	}`)
+	data := []byte(`
+	[
+		{
+			"orderListId": 29,
+			"contingencyType": "OCO",
+			"listStatusType": "EXEC_STARTED",
+			"listOrderStatus": "EXECUTING",
+			"listClientOrderId": "amEEAXryFzFwYF1FeRpUoZ",
+			"transactionTime": 1565245913483,
+			"symbol": "LTCBTC",
+			"orders": [
+				{
+					"symbol": "LTCBTC",
+					"orderId": 4,
+					"clientOrderId": "oD7aesZqjEGlZrbtRpy5zB"
+				},
+				{
+					"symbol": "LTCBTC",
+					"orderId": 5,
+					"clientOrderId": "Jr1h6xirOxgeJOUuYQS7V3"
+				}
+			]
+		},
+		{
+			"orderListId": 28,
+			"contingencyType": "OCO",
+			"listStatusType": "EXEC_STARTED",
+			"listOrderStatus": "EXECUTING",
+			"listClientOrderId": "hG7hFNxJV6cZy3Ze4AUT4d",
+			"transactionTime": 1565245913407,
+			"symbol": "LTCBTC",
+			"orders": [
+				{
+					"symbol": "LTCBTC",
+					"orderId": 2,
+					"clientOrderId": "j6lFOfbmFMRjTYA7rRJ0LP"
+				},
+				{
+					"symbol": "LTCBTC",
+					"orderId": 3,
+					"clientOrderId": "z0KCjOdditiLS5ekAFtK81"
+				}
+			]
+		}
+	]`)
 
 	s.mockDo(data, nil)
 	defer s.assertDo()
 
-	response, err := s.client.NewQueryAllOCOService().FromId(123456).StartTime(1616976140402).Limit(100).Do(context.Background())
+	resp, err := s.client.NewQueryAllOCOService().
+		FromId(123456).
+		StartTime(1616976140402).
+		Limit(100).
+		Do(context.Background())
+
 	s.r().NoError(err)
-
-	s.assertOCOResponseEqual(&OCOResponse{
-		OrderListId:       123456,
-		ContingencyType:   "OCO",
-		ListStatusType:    "EXEC_STARTED",
-		ListOrderStatus:   "EXECUTING",
-		ListClientOrderId: "myListClientOrderId",
-		TransactionTime:   1616976140402,
-		Symbol:            "BTCUSDT",
-		Orders: []struct {
-			Symbol        string `json:"symbol"`
-			OrderId       int64  `json:"orderId"`
-			ClientOrderId string `json:"clientOrderId"`
-		}{
-			{
-				Symbol:        "BTCUSDT",
-				OrderId:       654321,
-				ClientOrderId: "myClientOrderId",
-			},
-		},
-	}, response)
-}
-
-func (s *accountTestSuite) assertOCOResponseEqual(expected, other *OCOResponse) {
-	r := s.r()
-
-	r.EqualValues(expected.OrderListId, other.OrderListId)
-	r.EqualValues(expected.ContingencyType, other.ContingencyType)
-	r.EqualValues(expected.ListStatusType, other.ListStatusType)
-	r.EqualValues(expected.ListOrderStatus, other.ListOrderStatus)
-	r.EqualValues(expected.ListClientOrderId, other.ListClientOrderId)
-	r.EqualValues(expected.TransactionTime, other.TransactionTime)
-	r.EqualValues(expected.Symbol, other.Symbol)
-
-	r.Len(other.Orders, len(expected.Orders))
-	for i, order := range expected.Orders {
-		r.EqualValues(order.Symbol, other.Orders[i].Symbol)
-		r.EqualValues(order.OrderId, other.Orders[i].OrderId)
-		r.EqualValues(order.ClientOrderId, other.Orders[i].ClientOrderId)
-	}
+	s.r().Equal(2, len(resp))
+	s.r().Equal(int64(29), resp[0].OrderListId)
+	s.r().Equal(int64(28), resp[1].OrderListId)
+	s.r().Equal("OCO", resp[0].ContingencyType)
+	s.r().Equal("OCO", resp[1].ContingencyType)
+	s.r().Equal("EXEC_STARTED", resp[0].ListStatusType)
+	s.r().Equal("EXEC_STARTED", resp[1].ListStatusType)
+	s.r().Equal("EXECUTING", resp[0].ListOrderStatus)
+	s.r().Equal("EXECUTING", resp[1].ListOrderStatus)
+	s.r().Equal("amEEAXryFzFwYF1FeRpUoZ", resp[0].ListClientOrderId)
+	s.r().Equal("hG7hFNxJV6cZy3Ze4AUT4d", resp[1].ListClientOrderId)
+	s.r().Equal(uint64(1565245913483), resp[0].TransactionTime)
+	s.r().Equal(uint64(1565245913407), resp[1].TransactionTime)
+	s.r().Equal("LTCBTC", resp[0].Symbol)
+	s.r().Equal("LTCBTC", resp[1].Symbol)
+	s.r().Equal(2, len(resp[0].Orders))
+	s.r().Equal(2, len(resp[1].Orders))
+	s.r().Equal("LTCBTC", resp[0].Orders[0].Symbol)
+	s.r().Equal("LTCBTC", resp[0].Orders[1].Symbol)
+	s.r().Equal("LTCBTC", resp[1].Orders[0].Symbol)
+	s.r().Equal("LTCBTC", resp[1].Orders[1].Symbol)
+	s.r().Equal(int64(4), resp[0].Orders[0].OrderId)
+	s.r().Equal(int64(5), resp[0].Orders[1].OrderId)
+	s.r().Equal(int64(2), resp[1].Orders[0].OrderId)
+	s.r().Equal(int64(3), resp[1].Orders[1].OrderId)
+	s.r().Equal("oD7aesZqjEGlZrbtRpy5zB", resp[0].Orders[0].ClientOrderId)
+	s.r().Equal("Jr1h6xirOxgeJOUuYQS7V3", resp[0].Orders[1].ClientOrderId)
+	s.r().Equal("j6lFOfbmFMRjTYA7rRJ0LP", resp[1].Orders[0].ClientOrderId)
+	s.r().Equal("z0KCjOdditiLS5ekAFtK81", resp[1].Orders[1].ClientOrderId)
 }
 
 func (s *accountTestSuite) TestGetOpenOrders() {

--- a/client.go
+++ b/client.go
@@ -65,6 +65,7 @@ func (c *Client) debug(format string, v ...interface{}) {
 	}
 }
 
+// Create client function for initialising new Binance client
 func NewClient(apiKey string, secretKey string, baseURL ...string) *Client {
 	url := "https://api.binance.com"
 
@@ -81,7 +82,6 @@ func NewClient(apiKey string, secretKey string, baseURL ...string) *Client {
 	}
 }
 
-// Create client function for initialising new Binance client:
 func (c *Client) parseRequest(r *request, opts ...RequestOption) (err error) {
 	// set request options from user
 	for _, opt := range opts {
@@ -142,8 +142,10 @@ func (c *Client) parseRequest(r *request, opts ...RequestOption) (err error) {
 
 func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption) (data []byte, err error) {
 	err = c.parseRequest(r, opts...)
-	if err != nil {
-		return []byte{}, err
+	if r.endpoint != "/api/v3/order/cancelReplace" {
+		if err != nil {
+			return []byte{}, err
+		}
 	}
 	req, err := http.NewRequest(r.method, r.fullURL, r.body)
 	if err != nil {
@@ -182,7 +184,9 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 		if e != nil {
 			c.debug("failed to unmarshal json: %s", e)
 		}
-		return nil, apiErr
+		if r.endpoint != "/api/v3/order/cancelReplace" {
+			return nil, apiErr
+		}
 	}
 	return data, nil
 }
@@ -685,6 +689,10 @@ func (c *Client) NewQueryManagedSubAccountList() *QueryManagedSubAccountList {
 
 func (c *Client) NewQuerySubAccountTransactionTatistics() *QuerySubAccountTransactionTatistics {
 	return &QuerySubAccountTransactionTatistics{c: c}
+}
+
+func (c *Client) NewGetManagedSubAccountDepositAddressService() *GetManagedSubAccountDepositAddressService {
+	return &GetManagedSubAccountDepositAddressService{c: c}
 }
 
 // Wallet Endpoints:

--- a/consts.go
+++ b/consts.go
@@ -2,4 +2,4 @@ package binance_connector
 
 const Name = "binance-connector-go"
 
-const Version = "0.2.0"
+const Version = "0.3.0"

--- a/examples/account/CancelReplace/CancelReplace.go
+++ b/examples/account/CancelReplace/CancelReplace.go
@@ -20,7 +20,7 @@ func CancelReplace() {
 
 	// Cancel an Existing Order and Send a New Order (TRADE) - POST /api/v3/order/cancelReplace
 	cancelReplace, err := client.NewCancelReplaceService().
-		Symbol("BTCUSDT").Side("BUY").OrderType("LIMIT").CancelReplaceMode("STOP_ON_FAILURE").
+		Symbol("BTCUSDT").Side("BUY").OrderType("LIMIT").CancelReplaceMode("STOP_ON_FAILURE").CancelOrderId(13341128).
 		TimeInForce("GTC").Quantity(0.001).Price(20000.0).Do(context.Background())
 	if err != nil {
 		fmt.Println(err)

--- a/examples/subaccount/GetManagedSubAccountDepositAddress/GetManagedSubAccountDepositAddress.go
+++ b/examples/subaccount/GetManagedSubAccountDepositAddress/GetManagedSubAccountDepositAddress.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	binance_connector "github.com/binance/binance-connector-go"
+)
+
+func main() {
+	GetManagedSubAccountDepositAddress()
+}
+
+func GetManagedSubAccountDepositAddress() {
+	apiKey := "your api key"
+	secretKey := "your secret key"
+	baseURL := "https://api.binance.com"
+
+	client := binance_connector.NewClient(apiKey, secretKey, baseURL)
+
+	// Get Managed Sub-account Deposit Address (For Investor Master Account) - /sapi/v1/managed-subaccount/deposit/address
+	GetManagedSubAccountDepositAddress, err := client.NewGetManagedSubAccountDepositAddressService().Email("from@email.com").
+		Coin("BTC").Network("BTC").Do(context.Background())
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println(binance_connector.PrettyPrint(GetManagedSubAccountDepositAddress))
+}

--- a/market.go
+++ b/market.go
@@ -417,7 +417,7 @@ func (s *Klines) Do(ctx context.Context, opts ...RequestOption) (res []*KlinesRe
 	r.setParam("symbol", s.symbol)
 	r.setParam("interval", s.interval)
 	if s.limit != nil {
-		r.setParam("interval", *s.limit)
+		r.setParam("limit", *s.limit)
 	}
 	if s.startTime != nil {
 		r.setParam("startTime", *s.startTime)
@@ -534,7 +534,7 @@ func (s *UiKlines) Do(ctx context.Context, opts ...RequestOption) (res []*UiKlin
 	r.setParam("symbol", s.symbol)
 	r.setParam("interval", s.interval)
 	if s.limit != nil {
-		r.setParam("interval", *s.limit)
+		r.setParam("limit", *s.limit)
 	}
 	if s.startTime != nil {
 		r.setParam("startTime", *s.startTime)

--- a/request.go
+++ b/request.go
@@ -66,5 +66,12 @@ func (r *request) validate() (err error) {
 	return nil
 }
 
+// Append `WithRecvWindow(insert_recvwindow)` to request to modify the default recvWindow value
+func WithRecvWindow(recvWindow int64) RequestOption {
+	return func(r *request) {
+		r.recvWindow = recvWindow
+	}
+}
+
 // RequestOption define option type for request
 type RequestOption func(*request)

--- a/subaccount.go
+++ b/subaccount.go
@@ -22,14 +22,14 @@ func (s *CreateSubAccountService) SubAccountString(subAccountString string) *Cre
 	return s
 }
 
-func (s *CreateSubAccountService) Do(ctx context.Context) (res *CreateSubAccountResp, err error) {
+func (s *CreateSubAccountService) Do(ctx context.Context, opts ...RequestOption) (res *CreateSubAccountResp, err error) {
 	r := &request{
 		method:   http.MethodPost,
 		endpoint: enableSubAccountEndpoint,
 		secType:  secTypeSigned,
 	}
 	r.setParam("subAccountString", s.subAccountString)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (s *QuerySubAccountListService) Limit(limit int) *QuerySubAccountListServic
 	return s
 }
 
-func (s *QuerySubAccountListService) Do(ctx context.Context) (res *SubAccountListResp, err error) {
+func (s *QuerySubAccountListService) Do(ctx context.Context, opts ...RequestOption) (res *SubAccountListResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: querySubAccountListEndpoint,
@@ -96,7 +96,7 @@ func (s *QuerySubAccountListService) Do(ctx context.Context) (res *SubAccountLis
 	if s.limit != nil {
 		r.setParam("limit", s.limit)
 	}
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func (s *QuerySubAccountSpotAssetTransferHistoryService) Limit(limit int) *Query
 	return s
 }
 
-func (s *QuerySubAccountSpotAssetTransferHistoryService) Do(ctx context.Context) (res *QuerySubAccountSpotAssetTransferHistoryResp, err error) {
+func (s *QuerySubAccountSpotAssetTransferHistoryService) Do(ctx context.Context, opts ...RequestOption) (res *QuerySubAccountSpotAssetTransferHistoryResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: querySubAccountSpotAssetTransferHistoryEndpoint,
@@ -189,7 +189,7 @@ func (s *QuerySubAccountSpotAssetTransferHistoryService) Do(ctx context.Context)
 	if s.limit != nil {
 		r.setParam("limit", s.limit)
 	}
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +258,7 @@ func (s *QuerySubAccountFuturesAssetTransferHistoryService) Limit(limit int) *Qu
 	return s
 }
 
-func (s *QuerySubAccountFuturesAssetTransferHistoryService) Do(ctx context.Context) (res *QuerySubAccountFuturesAssetTransferHistoryResp, err error) {
+func (s *QuerySubAccountFuturesAssetTransferHistoryService) Do(ctx context.Context, opts ...RequestOption) (res *QuerySubAccountFuturesAssetTransferHistoryResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: querySubAccountFuturesAssetTransferHistoryEndpoint,
@@ -278,7 +278,7 @@ func (s *QuerySubAccountFuturesAssetTransferHistoryService) Do(ctx context.Conte
 	if s.limit != nil {
 		r.setParam("limit", s.limit)
 	}
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -342,7 +342,7 @@ func (s *SubAccountFuturesAssetTransferService) Amount(amount float32) *SubAccou
 	return s
 }
 
-func (s *SubAccountFuturesAssetTransferService) Do(ctx context.Context) (res *SubAccountFuturesAssetTransferResp, err error) {
+func (s *SubAccountFuturesAssetTransferService) Do(ctx context.Context, opts ...RequestOption) (res *SubAccountFuturesAssetTransferResp, err error) {
 	r := &request{
 		method:   http.MethodPost,
 		endpoint: subAccountFuturesAssetTransferEndpoint,
@@ -353,7 +353,7 @@ func (s *SubAccountFuturesAssetTransferService) Do(ctx context.Context) (res *Su
 	r.setParam("futuresType", s.futuresType)
 	r.setParam("asset", s.asset)
 	r.setParam("amount", s.amount)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -385,14 +385,14 @@ func (s *QuerySubAccountAssetsService) Email(email string) *QuerySubAccountAsset
 	return s
 }
 
-func (s *QuerySubAccountAssetsService) Do(ctx context.Context) (res *QuerySubAccountAssetsResp, err error) {
+func (s *QuerySubAccountAssetsService) Do(ctx context.Context, opts ...RequestOption) (res *QuerySubAccountAssetsResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: querySubAccountAssetsEndpoint,
 		secType:  secTypeSigned,
 	}
 	r.setParam("email", s.email)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -439,7 +439,7 @@ func (s *QuerySubAccountSpotAssetsSummaryService) Size(size int) *QuerySubAccoun
 	return s
 }
 
-func (s *QuerySubAccountSpotAssetsSummaryService) Do(ctx context.Context) (res *QuerySubAccountSpotAssetsSummaryResp, err error) {
+func (s *QuerySubAccountSpotAssetsSummaryService) Do(ctx context.Context, opts ...RequestOption) (res *QuerySubAccountSpotAssetsSummaryResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: querySubAccountSpotAssetsSummaryEndpoint,
@@ -454,7 +454,7 @@ func (s *QuerySubAccountSpotAssetsSummaryService) Do(ctx context.Context) (res *
 	if s.size != nil {
 		r.setParam("size", *s.size)
 	}
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -502,7 +502,7 @@ func (s *GetSubAccountDepositAddressService) Network(network string) *GetSubAcco
 	return s
 }
 
-func (s *GetSubAccountDepositAddressService) Do(ctx context.Context) (res *GetSubAccountDepositAddressResp, err error) {
+func (s *GetSubAccountDepositAddressService) Do(ctx context.Context, opts ...RequestOption) (res *GetSubAccountDepositAddressResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: getSubAccountDepositAddressEndpoint,
@@ -513,7 +513,7 @@ func (s *GetSubAccountDepositAddressService) Do(ctx context.Context) (res *GetSu
 	if s.network != nil {
 		r.setParam("network", *s.network)
 	}
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -583,7 +583,7 @@ func (s *GetSubAccountDepositHistoryService) Offset(offset int64) *GetSubAccount
 	return s
 }
 
-func (s *GetSubAccountDepositHistoryService) Do(ctx context.Context) (res *GetSubAccountDepositHistoryResp, err error) {
+func (s *GetSubAccountDepositHistoryService) Do(ctx context.Context, opts ...RequestOption) (res *GetSubAccountDepositHistoryResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: getSubAccountDepositHistoryEndpoint,
@@ -606,7 +606,7 @@ func (s *GetSubAccountDepositHistoryService) Do(ctx context.Context) (res *GetSu
 	if s.offset != nil {
 		r.setParam("offset", *s.offset)
 	}
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -651,7 +651,7 @@ func (s *GetSubAccountStatusService) Email(email string) *GetSubAccountStatusSer
 	return s
 }
 
-func (s *GetSubAccountStatusService) Do(ctx context.Context) (res *GetSubAccountStatusResp, err error) {
+func (s *GetSubAccountStatusService) Do(ctx context.Context, opts ...RequestOption) (res *GetSubAccountStatusResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: getSubAccountStatusEndpoint,
@@ -660,7 +660,7 @@ func (s *GetSubAccountStatusService) Do(ctx context.Context) (res *GetSubAccount
 	if s.email != nil {
 		r.setParam("email", *s.email)
 	}
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -697,14 +697,14 @@ func (s *EnableMarginForSubAccountService) Email(email string) *EnableMarginForS
 	return s
 }
 
-func (s *EnableMarginForSubAccountService) Do(ctx context.Context) (res *EnableMarginForSubAccountResp, err error) {
+func (s *EnableMarginForSubAccountService) Do(ctx context.Context, opts ...RequestOption) (res *EnableMarginForSubAccountResp, err error) {
 	r := &request{
 		method:   http.MethodPost,
 		endpoint: enableMarginForSubAccountEndpoint,
 		secType:  secTypeSigned,
 	}
 	r.setParam("email", s.email)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -736,14 +736,14 @@ func (s *GetDetailOnSubAccountMarginAccountService) Email(email string) *GetDeta
 	return s
 }
 
-func (s *GetDetailOnSubAccountMarginAccountService) Do(ctx context.Context) (res *GetDetailOnSubAccountMarginAccountResp, err error) {
+func (s *GetDetailOnSubAccountMarginAccountService) Do(ctx context.Context, opts ...RequestOption) (res *GetDetailOnSubAccountMarginAccountResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: getDetailOnSubAccountMarginAccountEndpoint,
 		secType:  secTypeSigned,
 	}
 	r.setParam("email", s.email)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -785,13 +785,13 @@ type GetSummaryOfSubAccountMarginAccountService struct {
 	c *Client
 }
 
-func (s *GetSummaryOfSubAccountMarginAccountService) Do(ctx context.Context) (res *GetSummaryOfSubAccountMarginAccountResp, err error) {
+func (s *GetSummaryOfSubAccountMarginAccountService) Do(ctx context.Context, opts ...RequestOption) (res *GetSummaryOfSubAccountMarginAccountResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: getSummaryOfSubAccountMarginAccountEndpoint,
 		secType:  secTypeSigned,
 	}
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -830,14 +830,14 @@ func (s *EnableFuturesForSubAccountService) Email(email string) *EnableFuturesFo
 	return s
 }
 
-func (s *EnableFuturesForSubAccountService) Do(ctx context.Context) (res *EnableFuturesForSubAccountResp, err error) {
+func (s *EnableFuturesForSubAccountService) Do(ctx context.Context, opts ...RequestOption) (res *EnableFuturesForSubAccountResp, err error) {
 	r := &request{
 		method:   http.MethodPost,
 		endpoint: enableFuturesForSubAccountEndpoint,
 		secType:  secTypeSigned,
 	}
 	r.setParam("email", s.email)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -869,14 +869,14 @@ func (s *GetDetailOnSubAccountFuturesAccountService) Email(email string) *GetDet
 	return s
 }
 
-func (s *GetDetailOnSubAccountFuturesAccountService) Do(ctx context.Context) (res *GetDetailOnSubAccountFuturesAccountResp, err error) {
+func (s *GetDetailOnSubAccountFuturesAccountService) Do(ctx context.Context, opts ...RequestOption) (res *GetDetailOnSubAccountFuturesAccountResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: getDetailOnSubAccountFuturesAccountEndpoint,
 		secType:  secTypeSigned,
 	}
 	r.setParam("email", s.email)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -926,13 +926,13 @@ type GetSummaryOfSubAccountFuturesAccountService struct {
 	c *Client
 }
 
-func (s *GetSummaryOfSubAccountFuturesAccountService) Do(ctx context.Context) (res *GetSummaryOfSubAccountFuturesAccountResp, err error) {
+func (s *GetSummaryOfSubAccountFuturesAccountService) Do(ctx context.Context, opts ...RequestOption) (res *GetSummaryOfSubAccountFuturesAccountResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: getSummaryOfSubAccountFuturesAccountEndpoint,
 		secType:  secTypeSigned,
 	}
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -981,14 +981,14 @@ func (s *GetFuturesPositionRiskOfSubAccountService) Email(email string) *GetFutu
 	return s
 }
 
-func (s *GetFuturesPositionRiskOfSubAccountService) Do(ctx context.Context) (res *GetFuturesPositionRiskOfSubAccountResp, err error) {
+func (s *GetFuturesPositionRiskOfSubAccountService) Do(ctx context.Context, opts ...RequestOption) (res *GetFuturesPositionRiskOfSubAccountResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: getFuturesPositionRiskOfSubAccountEndpoint,
 		secType:  secTypeSigned,
 	}
 	r.setParam("email", s.email)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1044,7 +1044,7 @@ func (s *FuturesTransferForSubAccountService) TransferType(transferType int) *Fu
 	return s
 }
 
-func (s *FuturesTransferForSubAccountService) Do(ctx context.Context) (res *FuturesTransferForSubAccountResp, err error) {
+func (s *FuturesTransferForSubAccountService) Do(ctx context.Context, opts ...RequestOption) (res *FuturesTransferForSubAccountResp, err error) {
 	r := &request{
 		method:   http.MethodPost,
 		endpoint: futuresTransferForSubAccountEndpoint,
@@ -1054,7 +1054,7 @@ func (s *FuturesTransferForSubAccountService) Do(ctx context.Context) (res *Futu
 	r.setParam("asset", s.asset)
 	r.setParam("amount", s.amount)
 	r.setParam("type", s.transferType)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1103,7 +1103,7 @@ func (s *MarginTransferForSubAccountService) TransferType(transferType int) *Mar
 	return s
 }
 
-func (s *MarginTransferForSubAccountService) Do(ctx context.Context) (res *MarginTransferForSubAccountResp, err error) {
+func (s *MarginTransferForSubAccountService) Do(ctx context.Context, opts ...RequestOption) (res *MarginTransferForSubAccountResp, err error) {
 	r := &request{
 		method:   http.MethodPost,
 		endpoint: marginTransferForSubAccountEndpoint,
@@ -1113,7 +1113,7 @@ func (s *MarginTransferForSubAccountService) Do(ctx context.Context) (res *Margi
 	r.setParam("asset", s.asset)
 	r.setParam("amount", s.amount)
 	r.setParam("type", s.transferType)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1156,7 +1156,7 @@ func (s *TransferToSubAccountOfSameMasterService) Amount(amount float64) *Transf
 	return s
 }
 
-func (s *TransferToSubAccountOfSameMasterService) Do(ctx context.Context) (res *TransferToSubAccountOfSameMasterResp, err error) {
+func (s *TransferToSubAccountOfSameMasterService) Do(ctx context.Context, opts ...RequestOption) (res *TransferToSubAccountOfSameMasterResp, err error) {
 	r := &request{
 		method:   http.MethodPost,
 		endpoint: transferToSubAccountOfSameMasterEndpoint,
@@ -1165,7 +1165,7 @@ func (s *TransferToSubAccountOfSameMasterService) Do(ctx context.Context) (res *
 	r.setParam("toEmail", s.toEmail)
 	r.setParam("asset", s.asset)
 	r.setParam("amount", s.amount)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1202,7 +1202,7 @@ func (s *TransferToMasterService) Amount(amount float64) *TransferToMasterServic
 	return s
 }
 
-func (s *TransferToMasterService) Do(ctx context.Context) (res *TransferToMasterResp, err error) {
+func (s *TransferToMasterService) Do(ctx context.Context, opts ...RequestOption) (res *TransferToMasterResp, err error) {
 	r := &request{
 		method:   http.MethodPost,
 		endpoint: transferToMasterEndpoint,
@@ -1210,7 +1210,7 @@ func (s *TransferToMasterService) Do(ctx context.Context) (res *TransferToMaster
 	}
 	r.setParam("asset", s.asset)
 	r.setParam("amount", s.amount)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1265,7 +1265,7 @@ func (s *SubAccountTransferHistoryService) Limit(limit int) *SubAccountTransferH
 	return s
 }
 
-func (s *SubAccountTransferHistoryService) Do(ctx context.Context) (res *SubAccountTransferHistoryResp, err error) {
+func (s *SubAccountTransferHistoryService) Do(ctx context.Context, opts ...RequestOption) (res *SubAccountTransferHistoryResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: subAccountTransferHistoryEndpoint,
@@ -1286,7 +1286,7 @@ func (s *SubAccountTransferHistoryService) Do(ctx context.Context) (res *SubAcco
 	if s.limit != nil {
 		r.setParam("limit", *s.limit)
 	}
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1368,7 +1368,7 @@ func (s *UniversalTransferService) Amount(amount float64) *UniversalTransferServ
 	return s
 }
 
-func (s *UniversalTransferService) Do(ctx context.Context) (res *UniversalTransferResp, err error) {
+func (s *UniversalTransferService) Do(ctx context.Context, opts ...RequestOption) (res *UniversalTransferResp, err error) {
 	r := &request{
 		method:   http.MethodPost,
 		endpoint: universalTransferEndpoint,
@@ -1390,7 +1390,7 @@ func (s *UniversalTransferService) Do(ctx context.Context) (res *UniversalTransf
 	}
 	r.setParam("asset", s.asset)
 	r.setParam("amount", s.amount)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1517,7 +1517,7 @@ type InternalUniversalTransfer struct {
 
 // Get Detail on Sub-account's Futures Account V2 (For Master Account)
 const (
-	getDetailOnSubAccountFuturesAccountV2Endpoint = "/sapi/v1/sub-account/futures/internalTransfer"
+	getDetailOnSubAccountFuturesAccountV2Endpoint = "/sapi/v2/sub-account/futures/account"
 )
 
 type GetDetailOnSubAccountFuturesAccountV2Service struct {
@@ -1536,7 +1536,7 @@ func (s *GetDetailOnSubAccountFuturesAccountV2Service) FuturesType(futuresType i
 	return s
 }
 
-func (s *GetDetailOnSubAccountFuturesAccountV2Service) Do(ctx context.Context) (res *GetDetailOnSubAccountFuturesAccountV2Resp, err error) {
+func (s *GetDetailOnSubAccountFuturesAccountV2Service) Do(ctx context.Context, opts ...RequestOption) (res interface{}, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: getDetailOnSubAccountFuturesAccountV2Endpoint,
@@ -1544,11 +1544,15 @@ func (s *GetDetailOnSubAccountFuturesAccountV2Service) Do(ctx context.Context) (
 	}
 	r.setParam("email", s.email)
 	r.setParam("futuresType", s.futuresType)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
-	res = new(GetDetailOnSubAccountFuturesAccountV2Resp)
+	if s.futuresType == 1 {
+		res = new(GetDetailOnSubAccountFuturesAccountV2USDTResp)
+	} else {
+		res = new(GetDetailOnSubAccountFuturesAccountV2COINResp)
+	}
 	err = json.Unmarshal(data, res)
 	if err != nil {
 		return nil, err
@@ -1556,22 +1560,61 @@ func (s *GetDetailOnSubAccountFuturesAccountV2Service) Do(ctx context.Context) (
 	return res, nil
 }
 
-type GetDetailOnSubAccountFuturesAccountV2Resp struct {
-	Success     bool `json:"success"`
-	FuturesType int  `json:"futuresType"`
-	Transfers   []struct {
-		From   string `json:"from"`
-		To     string `json:"to"`
-		Asset  string `json:"asset"`
-		Qty    string `json:"qty"`
-		TranId int64  `json:"tranId"`
-		Time   uint64 `json:"time"`
-	} `json:"transfers"`
+type GetDetailOnSubAccountFuturesAccountV2USDTResp struct {
+	FutureAccountResp struct {
+		Email  string `json:"email"`
+		Assets []struct {
+			Asset                  string `json:"asset"`
+			InitialMargin          string `json:"initialMargin"`
+			MaintenanceMargin      string `json:"maintenanceMargin"`
+			MarginBalance          string `json:"marginBalance"`
+			MaxWithdrawAmount      string `json:"maxWithdrawAmount"`
+			OpenOrderInitialMargin string `json:"openOrderInitialMargin"`
+			PositionInitialMargin  string `json:"positionInitialMargin"`
+			UnrealizedProfit       string `json:"unrealizedProfit"`
+			WalletBalance          string `json:"walletBalance"`
+		} `json:"assets"`
+		CanDeposit                  bool   `json:"canDeposit"`
+		CanTrade                    bool   `json:"canTrade"`
+		CanWithdraw                 bool   `json:"canWithdraw"`
+		FeeTier                     int    `json:"feeTier"`
+		MaxWithdrawAmount           string `json:"maxWithdrawAmount"`
+		TotalInitialMargin          string `json:"totalInitialMargin"`
+		TotalMaintenanceMargin      string `json:"totalMaintenanceMargin"`
+		TotalMarginBalance          string `json:"totalMarginBalance"`
+		TotalOpenOrderInitialMargin string `json:"totalOpenOrderInitialMargin"`
+		TotalPositionInitialMargin  string `json:"totalPositionInitialMargin"`
+		TotalUnrealizedProfit       string `json:"totalUnrealizedProfit"`
+		TotalWalletBalance          string `json:"totalWalletBalance"`
+		UpdateTime                  uint64 `json:"updateTime"`
+	} `json:"futureAccountResp"`
+}
+
+type GetDetailOnSubAccountFuturesAccountV2COINResp struct {
+	DeliveryAccountResp struct {
+		Email  string `json:"email"`
+		Assets []struct {
+			Asset                  string `json:"asset"`
+			InitialMargin          string `json:"initialMargin"`
+			MaintenanceMargin      string `json:"maintenanceMargin"`
+			MarginBalance          string `json:"marginBalance"`
+			MaxWithdrawAmount      string `json:"maxWithdrawAmount"`
+			OpenOrderInitialMargin string `json:"openOrderInitialMargin"`
+			PositionInitialMargin  string `json:"positionInitialMargin"`
+			UnrealizedProfit       string `json:"unrealizedProfit"`
+			WalletBalance          string `json:"walletBalance"`
+		} `json:"assets"`
+		CanDeposit  bool   `json:"canDeposit"`
+		CanTrade    bool   `json:"canTrade"`
+		CanWithdraw bool   `json:"canWithdraw"`
+		FeeTier     int    `json:"feeTier"`
+		UpdateTime  uint64 `json:"updateTime"`
+	} `json:"deliveryAccountResp"`
 }
 
 // Get Summary of Sub-account's Futures Account V2 (For Master Account)
 const (
-	getSummaryOfSubAccountFuturesAccountV2Endpoint = "/sapi/v1/sub-account/futures/accountSummary"
+	getSummaryOfSubAccountFuturesAccountV2Endpoint = "/sapi/v2/sub-account/futures/accountSummary"
 )
 
 type GetSummaryOfSubAccountFuturesAccountV2Service struct {
@@ -1596,7 +1639,7 @@ func (s *GetSummaryOfSubAccountFuturesAccountV2Service) Limit(limit int) *GetSum
 	return s
 }
 
-func (s *GetSummaryOfSubAccountFuturesAccountV2Service) Do(ctx context.Context) (res *GetSummaryOfSubAccountFuturesAccountV2Resp, err error) {
+func (s *GetSummaryOfSubAccountFuturesAccountV2Service) Do(ctx context.Context, opts ...RequestOption) (res interface{}, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: getSummaryOfSubAccountFuturesAccountV2Endpoint,
@@ -1609,11 +1652,15 @@ func (s *GetSummaryOfSubAccountFuturesAccountV2Service) Do(ctx context.Context) 
 	if s.limit != nil {
 		r.setParam("limit", *s.limit)
 	}
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
-	res = new(GetSummaryOfSubAccountFuturesAccountV2Resp)
+	if s.futuresType == 1 {
+		res = new(GetSummaryOfSubAccountFuturesAccountV2USDTResp)
+	} else {
+		res = new(GetSummaryOfSubAccountFuturesAccountV2COINResp)
+	}
 	err = json.Unmarshal(data, res)
 	if err != nil {
 		return nil, err
@@ -1621,7 +1668,7 @@ func (s *GetSummaryOfSubAccountFuturesAccountV2Service) Do(ctx context.Context) 
 	return res, nil
 }
 
-type GetSummaryOfSubAccountFuturesAccountV2Resp struct {
+type GetSummaryOfSubAccountFuturesAccountV2USDTResp struct {
 	FutureAccountSummaryResp struct {
 		TotalInitialMargin          string `json:"totalInitialMargin"`
 		TotalMaintenanceMargin      string `json:"totalMaintenanceMargin"`
@@ -1645,9 +1692,25 @@ type GetSummaryOfSubAccountFuturesAccountV2Resp struct {
 	} `json:"futureAccountSummaryResp"`
 }
 
+type GetSummaryOfSubAccountFuturesAccountV2COINResp struct {
+	DeliveryAccountSummaryResp struct {
+		TotalMarginBalanceOfBTC    string `json:"totalMarginBalanceOfBTC"`
+		TotalUnrealizedProfitOfBTC string `json:"totalUnrealizedProfitOfBTC"`
+		TotalWalletBalanceOfBTC    string `json:"totalWalletBalanceOfBTC"`
+		Asset                      string `json:"asset"`
+		SubAccountList             []struct {
+			Email                 string `json:"email"`
+			TotalMarginBalance    string `json:"totalMarginBalance"`
+			TotalUnrealizedProfit string `json:"totalUnrealizedProfit"`
+			TotalWalletBalance    string `json:"totalWalletBalance"`
+			Asset                 string `json:"asset"`
+		} `json:"subAccountList"`
+	} `json:"deliveryAccountSummaryResp"`
+}
+
 // Get Futures Position-Risk of Sub-account V2 (For Master Account)
 const (
-	getFuturesPositionRiskOfSubAccountV2Endpoint = "/sapi/v1/sub-account/futures/positionRisk"
+	getFuturesPositionRiskOfSubAccountV2Endpoint = "/sapi/v2/sub-account/futures/positionRisk"
 )
 
 type GetFuturesPositionRiskOfSubAccountV2Service struct {
@@ -1666,7 +1729,7 @@ func (s *GetFuturesPositionRiskOfSubAccountV2Service) FuturesType(futuresType in
 	return s
 }
 
-func (s *GetFuturesPositionRiskOfSubAccountV2Service) Do(ctx context.Context) (res *GetFuturesPositionRiskOfSubAccountV2Resp, err error) {
+func (s *GetFuturesPositionRiskOfSubAccountV2Service) Do(ctx context.Context, opts ...RequestOption) (res interface{}, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: getFuturesPositionRiskOfSubAccountV2Endpoint,
@@ -1674,11 +1737,15 @@ func (s *GetFuturesPositionRiskOfSubAccountV2Service) Do(ctx context.Context) (r
 	}
 	r.setParam("email", s.email)
 	r.setParam("futuresType", s.futuresType)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
-	res = new(GetFuturesPositionRiskOfSubAccountV2Resp)
+	if s.futuresType == 1 {
+		res = new(GetFuturesPositionRiskOfSubAccountV2USDTResp)
+	} else {
+		res = new(GetFuturesPositionRiskOfSubAccountV2COINResp)
+	}
 	err = json.Unmarshal(data, res)
 	if err != nil {
 		return nil, err
@@ -1686,7 +1753,7 @@ func (s *GetFuturesPositionRiskOfSubAccountV2Service) Do(ctx context.Context) (r
 	return res, nil
 }
 
-type GetFuturesPositionRiskOfSubAccountV2Resp struct {
+type GetFuturesPositionRiskOfSubAccountV2USDTResp struct {
 	FuturePositionRiskVos []struct {
 		EntryPrice       string `json:"entryPrice"`
 		Leverage         string `json:"leverage"`
@@ -1697,6 +1764,22 @@ type GetFuturesPositionRiskOfSubAccountV2Resp struct {
 		Symbol           string `json:"symbol"`
 		UnrealizedProfit string `json:"unrealizedProfit"`
 	} `json:"futurePositionRiskVos"`
+}
+
+type GetFuturesPositionRiskOfSubAccountV2COINResp struct {
+	DeliveryPositionRiskVos []struct {
+		EntryPrice       string `json:"entryPrice"`
+		MarkPrice        string `json:"markPrice"`
+		Leverage         string `json:"leverage"`
+		Isolated         string `json:"isolated"`
+		IsolatedWallet   string `json:"isolatedWallet"`
+		IsolatedMargin   string `json:"isolatedMargin"`
+		IsAutoAddMargin  string `json:"isAutoAddMargin"`
+		PositionSide     string `json:"positionSide"`
+		PositionAmount   string `json:"positionAmount"`
+		Symbol           string `json:"symbol"`
+		UnrealizedProfit string `json:"unrealizedProfit"`
+	} `json:"deliveryPositionRiskVos"`
 }
 
 // Enable Leverage Token for Sub-account (For Master Account)
@@ -1720,7 +1803,7 @@ func (s *EnableLeverageTokenForSubAccountService) EnableBlvt(enableBlvt bool) *E
 	return s
 }
 
-func (s *EnableLeverageTokenForSubAccountService) Do(ctx context.Context) (res *EnableLeverageTokenForSubAccountResp, err error) {
+func (s *EnableLeverageTokenForSubAccountService) Do(ctx context.Context, opts ...RequestOption) (res *EnableLeverageTokenForSubAccountResp, err error) {
 	r := &request{
 		method:   http.MethodPost,
 		endpoint: enableLeverageTokenForSubAccountEndpoint,
@@ -1728,7 +1811,7 @@ func (s *EnableLeverageTokenForSubAccountService) Do(ctx context.Context) (res *
 	}
 	r.setParam("email", s.email)
 	r.setParam("enableBlvt", s.enableBlvt)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1767,7 +1850,7 @@ func (s *GetIPRestrictionForSubAccountAPIKeyService) SubAccountApiKey(subAccount
 	return s
 }
 
-func (s *GetIPRestrictionForSubAccountAPIKeyService) Do(ctx context.Context) (res *GetIPRestrictionForSubAccountAPIKeyResp, err error) {
+func (s *GetIPRestrictionForSubAccountAPIKeyService) Do(ctx context.Context, opts ...RequestOption) (res *GetIPRestrictionForSubAccountAPIKeyResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: getIPRestrictionForSubAccountAPIKeyEndpoint,
@@ -1775,7 +1858,7 @@ func (s *GetIPRestrictionForSubAccountAPIKeyService) Do(ctx context.Context) (re
 	}
 	r.setParam("email", s.email)
 	r.setParam("subAccountApiKey", s.subAccountApiKey)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1824,7 +1907,7 @@ func (s *DeleteIPListForSubAccountAPIKeyService) IpAddress(ipAddress string) *De
 	return s
 }
 
-func (s *DeleteIPListForSubAccountAPIKeyService) Do(ctx context.Context) (res *DeleteIPListForSubAccountAPIKeyResp, err error) {
+func (s *DeleteIPListForSubAccountAPIKeyService) Do(ctx context.Context, opts ...RequestOption) (res *DeleteIPListForSubAccountAPIKeyResp, err error) {
 	r := &request{
 		method:   http.MethodDelete,
 		endpoint: deleteIPListForSubAccountAPIKeyEndpoint,
@@ -1835,7 +1918,7 @@ func (s *DeleteIPListForSubAccountAPIKeyService) Do(ctx context.Context) (res *D
 	if s.ipAddress != nil {
 		r.setParam("ipAddress", *s.ipAddress)
 	}
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1890,7 +1973,7 @@ func (s *UpdateIPRestrictionForSubAccountAPIKeyService) IpAddress(ipAddress stri
 	return s
 }
 
-func (s *UpdateIPRestrictionForSubAccountAPIKeyService) Do(ctx context.Context) (res *UpdateIPRestrictionForSubAccountAPIKeyResp, err error) {
+func (s *UpdateIPRestrictionForSubAccountAPIKeyService) Do(ctx context.Context, opts ...RequestOption) (res *UpdateIPRestrictionForSubAccountAPIKeyResp, err error) {
 	r := &request{
 		method:   http.MethodPut,
 		endpoint: updateIPRestrictionForSubAccountAPIKeyEndpoint,
@@ -1902,7 +1985,7 @@ func (s *UpdateIPRestrictionForSubAccountAPIKeyService) Do(ctx context.Context) 
 	if s.ipAddress != nil {
 		r.setParam("ipAddress", *s.ipAddress)
 	}
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1951,7 +2034,7 @@ func (s *DepositAssetsIntoTheManagedSubAccountService) Amount(amount float64) *D
 	return s
 }
 
-func (s *DepositAssetsIntoTheManagedSubAccountService) Do(ctx context.Context) (res *DepositAssetsIntoTheManagedSubAccountResp, err error) {
+func (s *DepositAssetsIntoTheManagedSubAccountService) Do(ctx context.Context, opts ...RequestOption) (res *DepositAssetsIntoTheManagedSubAccountResp, err error) {
 	r := &request{
 		method:   http.MethodPost,
 		endpoint: depositAssetsIntoTheManagedSubAccountEndpoint,
@@ -1960,7 +2043,7 @@ func (s *DepositAssetsIntoTheManagedSubAccountService) Do(ctx context.Context) (
 	r.setParam("toEmail", s.toEmail)
 	r.setParam("asset", s.asset)
 	r.setParam("amount", s.amount)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1992,14 +2075,14 @@ func (s *QueryManagedSubAccountAssetDetailsService) Email(email string) *QueryMa
 	return s
 }
 
-func (s *QueryManagedSubAccountAssetDetailsService) Do(ctx context.Context) (res *QueryManagedSubAccountAssetDetailsResp, err error) {
+func (s *QueryManagedSubAccountAssetDetailsService) Do(ctx context.Context, opts ...RequestOption) (res *QueryManagedSubAccountAssetDetailsResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: queryManagedSubAccountAssetDetailsEndpoint,
 		secType:  secTypeSigned,
 	}
 	r.setParam("email", s.email)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -2056,7 +2139,7 @@ func (s *WithdrawAssetsFromTheManagedSubAccountService) TransferDate(transferDat
 	return s
 }
 
-func (s *WithdrawAssetsFromTheManagedSubAccountService) Do(ctx context.Context) (res *WithdrawAssetsFromTheManagedSubAccountResp, err error) {
+func (s *WithdrawAssetsFromTheManagedSubAccountService) Do(ctx context.Context, opts ...RequestOption) (res *WithdrawAssetsFromTheManagedSubAccountResp, err error) {
 	r := &request{
 		method:   http.MethodPost,
 		endpoint: withdrawAssetsFromTheManagedSubAccountEndpoint,
@@ -2068,7 +2151,7 @@ func (s *WithdrawAssetsFromTheManagedSubAccountService) Do(ctx context.Context) 
 	if s.transferDate != nil {
 		r.setParam("transferDate", *s.transferDate)
 	}
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -2124,7 +2207,7 @@ func (s *QueryManagedSubAccountSnapshotService) Limit(limit int) *QueryManagedSu
 	return s
 }
 
-func (s *QueryManagedSubAccountSnapshotService) Do(ctx context.Context) (res *QueryManagedSubAccountSnapshotResp, err error) {
+func (s *QueryManagedSubAccountSnapshotService) Do(ctx context.Context, opts ...RequestOption) (res *QueryManagedSubAccountSnapshotResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: queryManagedSubAccountSnapshotEndpoint,
@@ -2141,7 +2224,7 @@ func (s *QueryManagedSubAccountSnapshotService) Do(ctx context.Context) (res *Qu
 	if s.limit != nil {
 		r.setParam("limit", *s.limit)
 	}
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -2221,7 +2304,7 @@ func (s *QueryManagedSubAccountTransferLogService) TransferFunctionAccountType(t
 	return s
 }
 
-func (s *QueryManagedSubAccountTransferLogService) Do(ctx context.Context) (res *QueryManagedSubAccountTransferLogResp, err error) {
+func (s *QueryManagedSubAccountTransferLogService) Do(ctx context.Context, opts ...RequestOption) (res *QueryManagedSubAccountTransferLogResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: queryManagedSubAccountTransferLogEndpoint,
@@ -2238,7 +2321,7 @@ func (s *QueryManagedSubAccountTransferLogService) Do(ctx context.Context) (res 
 	if s.transferFunctionAccountType != nil {
 		r.setParam("transferFunctionAccountType", *s.transferFunctionAccountType)
 	}
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -2280,14 +2363,14 @@ func (s *QueryManagedSubAccountFuturesAssetDetailsService) Email(email string) *
 	return s
 }
 
-func (s *QueryManagedSubAccountFuturesAssetDetailsService) Do(ctx context.Context) (res *QueryManagedSubAccountFuturesAssetDetailsResp, err error) {
+func (s *QueryManagedSubAccountFuturesAssetDetailsService) Do(ctx context.Context, opts ...RequestOption) (res *QueryManagedSubAccountFuturesAssetDetailsResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: queryManagedSubAccountFuturesAssetDetailsEndpoint,
 		secType:  secTypeSigned,
 	}
 	r.setParam("email", s.email)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -2336,14 +2419,14 @@ func (s *QueryManagedSubAccountMarginAssetDetailsService) Email(email string) *Q
 	return s
 }
 
-func (s *QueryManagedSubAccountMarginAssetDetailsService) Do(ctx context.Context) (res *QueryManagedSubAccountMarginAssetDetailsResp, err error) {
+func (s *QueryManagedSubAccountMarginAssetDetailsService) Do(ctx context.Context, opts ...RequestOption) (res *QueryManagedSubAccountMarginAssetDetailsResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: queryManagedSubAccountMarginAssetDetailsEndpoint,
 		secType:  secTypeSigned,
 	}
 	r.setParam("email", s.email)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -2421,7 +2504,7 @@ func (s *QueryManagedSubAccountTransferLogForTradingTeamService) TransferFunctio
 	return s
 }
 
-func (s *QueryManagedSubAccountTransferLogForTradingTeamService) Do(ctx context.Context) (res *QueryManagedSubAccountTransferLogForTradingTeamResp, err error) {
+func (s *QueryManagedSubAccountTransferLogForTradingTeamService) Do(ctx context.Context, opts ...RequestOption) (res *QueryManagedSubAccountTransferLogForTradingTeamResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: queryManagedSubAccountTransferLogForTradingTeamEndpoint,
@@ -2438,7 +2521,7 @@ func (s *QueryManagedSubAccountTransferLogForTradingTeamService) Do(ctx context.
 	if s.transferFunctionAccountType != nil {
 		r.setParam("transferFunctionAccountType", *s.transferFunctionAccountType)
 	}
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -2480,14 +2563,14 @@ func (s *QuerySubAccountAssetsForMasterAccountService) Email(email string) *Quer
 	return s
 }
 
-func (s *QuerySubAccountAssetsForMasterAccountService) Do(ctx context.Context) (res *QuerySubAccountAssetsForMasterAccountResp, err error) {
+func (s *QuerySubAccountAssetsForMasterAccountService) Do(ctx context.Context, opts ...RequestOption) (res *QuerySubAccountAssetsForMasterAccountResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: querySubAccountAssetsForMasterAccountEndpoint,
 		secType:  secTypeSigned,
 	}
 	r.setParam("email", s.email)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -2534,7 +2617,7 @@ func (s *QueryManagedSubAccountList) Limit(limit int) *QueryManagedSubAccountLis
 	return s
 }
 
-func (s *QueryManagedSubAccountList) Do(ctx context.Context) (res *QueryManagedSubAccountListResp, err error) {
+func (s *QueryManagedSubAccountList) Do(ctx context.Context, opts ...RequestOption) (res *QueryManagedSubAccountListResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: queryManagedSubAccountListEndpoint,
@@ -2549,7 +2632,7 @@ func (s *QueryManagedSubAccountList) Do(ctx context.Context) (res *QueryManagedS
 	if s.limit != nil {
 		r.setParam("limit", strconv.Itoa(*s.limit))
 	}
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -2593,14 +2676,14 @@ func (s *QuerySubAccountTransactionTatistics) Email(email string) *QuerySubAccou
 	return s
 }
 
-func (s *QuerySubAccountTransactionTatistics) Do(ctx context.Context) (res *QuerySubAccountTransactionTatisticsResp, err error) {
+func (s *QuerySubAccountTransactionTatistics) Do(ctx context.Context, opts ...RequestOption) (res *QuerySubAccountTransactionTatisticsResp, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: QuerySubAccountTransactionTatisticsEndpoint,
 		secType:  secTypeSigned,
 	}
 	r.setParam("email", s.email)
-	data, err := s.c.callAPI(ctx, r)
+	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -2629,4 +2712,61 @@ type QuerySubAccountTransactionTatisticsResp struct {
 		BusdMargin  int   `json:"busdMargin"`
 		Date        int64 `json:"date"`
 	} `json:"tradeInfoVos"`
+}
+
+// Get Managed Sub-account Deposit Address (For Investor Master Account) (USER_DATA)
+const (
+	getManagedSubAccountDepositAddressEndpoint = "/sapi/v1/managed-subaccount/deposit/address"
+)
+
+type GetManagedSubAccountDepositAddressService struct {
+	c       *Client
+	email   string
+	coin    string
+	network *string
+}
+
+func (s *GetManagedSubAccountDepositAddressService) Email(email string) *GetManagedSubAccountDepositAddressService {
+	s.email = email
+	return s
+}
+
+func (s *GetManagedSubAccountDepositAddressService) Coin(coin string) *GetManagedSubAccountDepositAddressService {
+	s.coin = coin
+	return s
+}
+
+func (s *GetManagedSubAccountDepositAddressService) Network(network string) *GetManagedSubAccountDepositAddressService {
+	s.network = &network
+	return s
+}
+
+func (s *GetManagedSubAccountDepositAddressService) Do(ctx context.Context, opts ...RequestOption) (res *GetManagedSubAccountDepositAddressResp, err error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: getManagedSubAccountDepositAddressEndpoint,
+		secType:  secTypeSigned,
+	}
+	r.setParam("email", s.email)
+	r.setParam("coin", s.coin)
+	if s.network != nil {
+		r.setParam("network", *s.network)
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res = new(GetManagedSubAccountDepositAddressResp)
+	err = json.Unmarshal(data, res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+type GetManagedSubAccountDepositAddressResp struct {
+	Coin    string `json:"coin"`
+	Address string `json:"address"`
+	Tag     string `json:"tag"`
+	Url     string `json:"url"`
 }

--- a/subaccount_test.go
+++ b/subaccount_test.go
@@ -355,26 +355,35 @@ func (s *subAccountTestSuite) TestGetDetailOnSubAccountFuturesAccount() {
 func (s *subAccountTestSuite) TestGetDetailOnSubAccountFuturesAccountV2() {
 	data := []byte(`
 	{
-		"success": true,
-		"futuresType": 1,
-		"transfers": [
+		"futureAccountResp": {
+		"email": "abc@test.com",
+		"assets":[
 			{
-				"from": "aaa",
-				"to": "bbb",
-				"asset": "BTC",
-				"qty": "1.00000000",
-				"tranId": 123,
-				"time": 1613450271000
-			},
-			{
-				"from": "bbb",
-				"to": "aaa",
-				"asset": "ETH",
-				"qty": "10.00000000",
-				"tranId": 456,
-				"time": 1613450272000
-			}
-		]
+				"asset": "USDT",
+				"initialMargin": "0.00000000",
+				"maintenanceMargin": "0.00000000",
+				"marginBalance": "0.88308000",
+				"maxWithdrawAmount": "0.88308000",
+				"openOrderInitialMargin": "0.00000000",
+				"positionInitialMargin": "0.00000000",
+				"unrealizedProfit": "0.00000000",
+				"walletBalance": "0.88308000"
+			 }
+		],
+		"canDeposit": true,
+		"canTrade": true,
+		"canWithdraw": true,
+		"feeTier": 2,
+		"maxWithdrawAmount": "0.88308000",
+		"totalInitialMargin": "0.00000000",
+		"totalMaintenanceMargin": "0.00000000",
+		"totalMarginBalance": "0.88308000",
+		"totalOpenOrderInitialMargin": "0.00000000",
+		"totalPositionInitialMargin": "0.00000000",
+		"totalUnrealizedProfit": "0.00000000",
+		"totalWalletBalance": "0.88308000",
+		"updateTime": 1576756674610
+	 }
 	}
 	`)
 
@@ -387,21 +396,30 @@ func (s *subAccountTestSuite) TestGetDetailOnSubAccountFuturesAccountV2() {
 		Do(context.Background())
 
 	s.r().NoError(err)
-	s.True(resp.Success)
-	s.Equal(1, resp.FuturesType)
-	s.Len(resp.Transfers, 2)
-	s.Equal("aaa", resp.Transfers[0].From)
-	s.Equal("bbb", resp.Transfers[0].To)
-	s.Equal("BTC", resp.Transfers[0].Asset)
-	s.Equal("1.00000000", resp.Transfers[0].Qty)
-	s.Equal(int64(123), resp.Transfers[0].TranId)
-	s.Equal(uint64(1613450271000), resp.Transfers[0].Time)
-	s.Equal("bbb", resp.Transfers[1].From)
-	s.Equal("aaa", resp.Transfers[1].To)
-	s.Equal("ETH", resp.Transfers[1].Asset)
-	s.Equal("10.00000000", resp.Transfers[1].Qty)
-	s.Equal(int64(456), resp.Transfers[1].TranId)
-	s.Equal(uint64(1613450272000), resp.Transfers[1].Time)
+	s.Equal("abc@test.com", resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.Email)
+	s.Len(resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.Assets, 1)
+	s.Equal("USDT", resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.Assets[0].Asset)
+	s.Equal("0.00000000", resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.Assets[0].InitialMargin)
+	s.Equal("0.00000000", resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.Assets[0].MaintenanceMargin)
+	s.Equal("0.88308000", resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.Assets[0].MarginBalance)
+	s.Equal("0.88308000", resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.Assets[0].MaxWithdrawAmount)
+	s.Equal("0.00000000", resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.Assets[0].OpenOrderInitialMargin)
+	s.Equal("0.00000000", resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.Assets[0].PositionInitialMargin)
+	s.Equal("0.00000000", resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.Assets[0].UnrealizedProfit)
+	s.Equal("0.88308000", resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.Assets[0].WalletBalance)
+	s.True(resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.CanDeposit)
+	s.True(resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.CanTrade)
+	s.True(resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.CanWithdraw)
+	s.Equal(2, resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.FeeTier)
+	s.Equal("0.88308000", resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.MaxWithdrawAmount)
+	s.Equal("0.00000000", resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.TotalInitialMargin)
+	s.Equal("0.00000000", resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.TotalMaintenanceMargin)
+	s.Equal("0.88308000", resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.TotalMarginBalance)
+	s.Equal("0.00000000", resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.TotalOpenOrderInitialMargin)
+	s.Equal("0.00000000", resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.TotalPositionInitialMargin)
+	s.Equal("0.00000000", resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.TotalUnrealizedProfit)
+	s.Equal("0.88308000", resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.TotalWalletBalance)
+	s.Equal(uint64(1576756674610), resp.(*GetDetailOnSubAccountFuturesAccountV2USDTResp).FutureAccountResp.UpdateTime)
 }
 
 func (s *subAccountTestSuite) TestGetDetailOnSubAccountMarginAccount() {
@@ -489,18 +507,18 @@ func (s *subAccountTestSuite) TestGetFuturesPositionRiskOfSubAccountV2() {
 	data := []byte(`
 	{
 		"futurePositionRiskVos": [
-			{
-				"entryPrice": "56789.01234567",
-				"leverage": "1",
-				"maxNotional": "1000000",
-				"liquidationPrice": "55555.55555555",
-				"markPrice": "56789.01234567",
-				"positionAmount": "10",
-				"symbol": "BTCUSDT",
-				"unrealizedProfit": "0.001"
-			}
-		]
-	}`)
+		   {
+			  "entryPrice": "9975.12000",
+			  "leverage": "50",
+			  "maxNotional": "1000000",
+			  "liquidationPrice": "7963.54",
+			  "markPrice": "9973.50770517",
+			  "positionAmount": "0.010",
+			  "symbol": "BTCUSDT",
+			  "unrealizedProfit": "-0.01612295"
+		   }
+		 ]
+	  }`)
 
 	s.mockDo(data, nil)
 	defer s.assertDo()
@@ -511,15 +529,15 @@ func (s *subAccountTestSuite) TestGetFuturesPositionRiskOfSubAccountV2() {
 		Do(context.Background())
 
 	s.r().NoError(err)
-	s.Len(resp.FuturePositionRiskVos, 1)
-	s.Equal("56789.01234567", resp.FuturePositionRiskVos[0].EntryPrice)
-	s.Equal("1", resp.FuturePositionRiskVos[0].Leverage)
-	s.Equal("1000000", resp.FuturePositionRiskVos[0].MaxNotional)
-	s.Equal("55555.55555555", resp.FuturePositionRiskVos[0].LiquidationPrice)
-	s.Equal("56789.01234567", resp.FuturePositionRiskVos[0].MarkPrice)
-	s.Equal("10", resp.FuturePositionRiskVos[0].PositionAmount)
-	s.Equal("BTCUSDT", resp.FuturePositionRiskVos[0].Symbol)
-	s.Equal("0.001", resp.FuturePositionRiskVos[0].UnrealizedProfit)
+	s.Len(resp.(*GetFuturesPositionRiskOfSubAccountV2USDTResp).FuturePositionRiskVos, 1)
+	s.Equal("9975.12000", resp.(*GetFuturesPositionRiskOfSubAccountV2USDTResp).FuturePositionRiskVos[0].EntryPrice)
+	s.Equal("50", resp.(*GetFuturesPositionRiskOfSubAccountV2USDTResp).FuturePositionRiskVos[0].Leverage)
+	s.Equal("1000000", resp.(*GetFuturesPositionRiskOfSubAccountV2USDTResp).FuturePositionRiskVos[0].MaxNotional)
+	s.Equal("7963.54", resp.(*GetFuturesPositionRiskOfSubAccountV2USDTResp).FuturePositionRiskVos[0].LiquidationPrice)
+	s.Equal("9973.50770517", resp.(*GetFuturesPositionRiskOfSubAccountV2USDTResp).FuturePositionRiskVos[0].MarkPrice)
+	s.Equal("0.010", resp.(*GetFuturesPositionRiskOfSubAccountV2USDTResp).FuturePositionRiskVos[0].PositionAmount)
+	s.Equal("BTCUSDT", resp.(*GetFuturesPositionRiskOfSubAccountV2USDTResp).FuturePositionRiskVos[0].Symbol)
+	s.Equal("-0.01612295", resp.(*GetFuturesPositionRiskOfSubAccountV2USDTResp).FuturePositionRiskVos[0].UnrealizedProfit)
 }
 
 func (s *subAccountTestSuite) TestGetIPRestrictionForSubAccountAPIKey() {
@@ -739,24 +757,24 @@ func (s *subAccountTestSuite) TestGetSummaryOfSubAccountFuturesAccountV2() {
 		Do(context.Background())
 
 	s.r().NoError(err)
-	s.Equal("100.00000000", resp.FutureAccountSummaryResp.TotalInitialMargin)
-	s.Equal("50.00000000", resp.FutureAccountSummaryResp.TotalMaintenanceMargin)
-	s.Equal("150.00000000", resp.FutureAccountSummaryResp.TotalMarginBalance)
-	s.Equal("25.00000000", resp.FutureAccountSummaryResp.TotalOpenOrderInitialMargin)
-	s.Equal("75.00000000", resp.FutureAccountSummaryResp.TotalPositionInitialMargin)
-	s.Equal("10.00000000", resp.FutureAccountSummaryResp.TotalUnrealizedProfit)
-	s.Equal("160.00000000", resp.FutureAccountSummaryResp.TotalWalletBalance)
-	s.Equal("BTC", resp.FutureAccountSummaryResp.Asset)
-	s.Len(resp.FutureAccountSummaryResp.SubAccountList, 2)
-	s.Equal("test1@test.com", resp.FutureAccountSummaryResp.SubAccountList[0].Email)
-	s.Equal("50.00000000", resp.FutureAccountSummaryResp.SubAccountList[0].TotalInitialMargin)
-	s.Equal("25.00000000", resp.FutureAccountSummaryResp.SubAccountList[0].TotalMaintenanceMargin)
-	s.Equal("75.00000000", resp.FutureAccountSummaryResp.SubAccountList[0].TotalMarginBalance)
-	s.Equal("15.00000000", resp.FutureAccountSummaryResp.SubAccountList[0].TotalOpenOrderInitialMargin)
-	s.Equal("45.00000000", resp.FutureAccountSummaryResp.SubAccountList[0].TotalPositionInitialMargin)
-	s.Equal("5.00000000", resp.FutureAccountSummaryResp.SubAccountList[0].TotalUnrealizedProfit)
-	s.Equal("80.00000000", resp.FutureAccountSummaryResp.SubAccountList[0].TotalWalletBalance)
-	s.Equal("BTC", resp.FutureAccountSummaryResp.SubAccountList[0].Asset)
+	s.Equal("100.00000000", resp.(*GetSummaryOfSubAccountFuturesAccountV2USDTResp).FutureAccountSummaryResp.TotalInitialMargin)
+	s.Equal("50.00000000", resp.(*GetSummaryOfSubAccountFuturesAccountV2USDTResp).FutureAccountSummaryResp.TotalMaintenanceMargin)
+	s.Equal("150.00000000", resp.(*GetSummaryOfSubAccountFuturesAccountV2USDTResp).FutureAccountSummaryResp.TotalMarginBalance)
+	s.Equal("25.00000000", resp.(*GetSummaryOfSubAccountFuturesAccountV2USDTResp).FutureAccountSummaryResp.TotalOpenOrderInitialMargin)
+	s.Equal("75.00000000", resp.(*GetSummaryOfSubAccountFuturesAccountV2USDTResp).FutureAccountSummaryResp.TotalPositionInitialMargin)
+	s.Equal("10.00000000", resp.(*GetSummaryOfSubAccountFuturesAccountV2USDTResp).FutureAccountSummaryResp.TotalUnrealizedProfit)
+	s.Equal("160.00000000", resp.(*GetSummaryOfSubAccountFuturesAccountV2USDTResp).FutureAccountSummaryResp.TotalWalletBalance)
+	s.Equal("BTC", resp.(*GetSummaryOfSubAccountFuturesAccountV2USDTResp).FutureAccountSummaryResp.Asset)
+	s.Len(resp.(*GetSummaryOfSubAccountFuturesAccountV2USDTResp).FutureAccountSummaryResp.SubAccountList, 2)
+	s.Equal("test1@test.com", resp.(*GetSummaryOfSubAccountFuturesAccountV2USDTResp).FutureAccountSummaryResp.SubAccountList[0].Email)
+	s.Equal("50.00000000", resp.(*GetSummaryOfSubAccountFuturesAccountV2USDTResp).FutureAccountSummaryResp.SubAccountList[0].TotalInitialMargin)
+	s.Equal("25.00000000", resp.(*GetSummaryOfSubAccountFuturesAccountV2USDTResp).FutureAccountSummaryResp.SubAccountList[0].TotalMaintenanceMargin)
+	s.Equal("75.00000000", resp.(*GetSummaryOfSubAccountFuturesAccountV2USDTResp).FutureAccountSummaryResp.SubAccountList[0].TotalMarginBalance)
+	s.Equal("15.00000000", resp.(*GetSummaryOfSubAccountFuturesAccountV2USDTResp).FutureAccountSummaryResp.SubAccountList[0].TotalOpenOrderInitialMargin)
+	s.Equal("45.00000000", resp.(*GetSummaryOfSubAccountFuturesAccountV2USDTResp).FutureAccountSummaryResp.SubAccountList[0].TotalPositionInitialMargin)
+	s.Equal("5.00000000", resp.(*GetSummaryOfSubAccountFuturesAccountV2USDTResp).FutureAccountSummaryResp.SubAccountList[0].TotalUnrealizedProfit)
+	s.Equal("80.00000000", resp.(*GetSummaryOfSubAccountFuturesAccountV2USDTResp).FutureAccountSummaryResp.SubAccountList[0].TotalWalletBalance)
+	s.Equal("BTC", resp.(*GetSummaryOfSubAccountFuturesAccountV2USDTResp).FutureAccountSummaryResp.SubAccountList[0].Asset)
 }
 
 func (s *marginTestSuite) TestGetSummaryOfSubAccountMarginAccount() {
@@ -1535,4 +1553,43 @@ func (s *subAccountTestSuite) TestWithdrawAssetsFromTheManagedSubAccount() {
 
 	s.r().NoError(err)
 	s.Equal(int64(123), resp.TranId)
+}
+
+func (s *subAccountTestSuite) TestManagedSubaccountDepositAddressService() {
+	data := []byte(`
+	{
+		"coin": "USDT",
+		"address": "0x206c22d833bb0bb2102da6b7c7d4c3eb14bcf73d",
+		"tag": "",
+		"url": "https://etherscan.io/address/0x206c22d833bb0bb2102da6b7c7d4c3eb14bcf73d"
+	}
+	`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	email := "testsub@gmail.com"
+	coin := "a_coin"
+	network := "a_network"
+
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"email":   email,
+			"coin":    coin,
+			"network": network,
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	res, err := s.client.NewGetManagedSubAccountDepositAddressService().
+		Email(email).
+		Coin(coin).
+		Network(network).
+		Do(newContext())
+
+	r := s.r()
+	r.NoError(err)
+	r.Equal("0x206c22d833bb0bb2102da6b7c7d4c3eb14bcf73d", res.Address, "Address")
+	r.Equal("USDT", res.Coin, "Coin")
+	r.Equal("", res.Tag, "Tag")
+	r.Equal("https://etherscan.io/address/0x206c22d833bb0bb2102da6b7c7d4c3eb14bcf73d", res.Url, "URL")
 }


### PR DESCRIPTION
### Added
- New Endpoint, `NewGetManagedSubAccountDepositAddressService()`: `GET /sapi/v1/managed-subaccount/deposit/address` - Get Managed Sub-account Deposit Address (For Investor Master Account) (USER_DATA)

### Fixed
- Added separate USDT-M and COIN-M Response Types for relevant Subaccount Endpoints
- Added support for Conditional Fields in relevant responses on Account Endpoints
- Responses for `POST /api/v3/order/cancelReplace` support all 4 Response Types
- Support for specifying `recvWindow` via `WithRecvWindow()` function
- `strategyId` and `strategyType` parameters added to `TestNewOrder` and `CreateOrderService` endpoints
- `UiKlines`: corrected `limit` parameter to not be sent as `interval`