### PR TITLE
fix TestNewOrder bug

### DIFF
--- a/account.go
+++ b/account.go
@@ -122,7 +122,7 @@ func (s *TestNewOrder) Do(ctx context.Context, opts ...RequestOption) (res *Acco
 	r := &request{
 		method:   http.MethodPost,
 		endpoint: "/api/v3/order/test",
-		secType:  secTypeNone,
+		secType:  secTypeSigned,
 	}
 	r.setParam("symbol", s.symbol)
 	r.setParam("side", s.side)


### PR DESCRIPTION
Resolved the error: Mandatory parameter 'signature' was not sent, was empty/null, or malformed. 