### PR TITLE
Fix json unmarshal error in NewGetAllOrdersService

### DIFF
--- a/account.go
+++ b/account.go
@@ -1135,7 +1135,7 @@ type NewAllOrdersResponse struct {
 	UpdateTime              uint64 `json:"updateTime"`
 	IsWorking               bool   `json:"isWorking"`
 	OrigQuoteOrderQty       string `json:"origQuoteOrderQty"`
-	WorkingTime             uint64 `json:"workingTime"`
+	WorkingTime             int64  `json:"workingTime"`
 	SelfTradePreventionMode string `json:"selfTradePreventionMode"`
 	PreventedMatchId        int64  `json:"preventedMatchId,omitempty"`
 	PreventedQuantity       string `json:"preventedQuantity,omitempty"`


### PR DESCRIPTION
* WorkingTime of an canceled order is -1, which cause json unmarshal error in NewGetAllOrdersService
* Change the type of NewAllOrdersResponse.WorkingTime from uint64 to int64