### PR TITLE
Add C2C service with endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is a lightweight library that works as a connector to [Binance public API](
 
 ## Supported API Endpoints:
 - Account/Trade: `account.go`
+- C2C: `c2c.go`
 - Wallet: `wallet.go`
 - Margin Account/Trade: `margin.go`
 - Market Data: `market.go`

--- a/c2c.go
+++ b/c2c.go
@@ -1,0 +1,117 @@
+package binance_connector
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+const (
+	getC2CTradeHistory = "/sapi/v1/c2c/orderMatch/listUserOrderHistory"
+)
+
+// Request requirements
+// The max interval between startTime and endTime is 30 days.
+// If startTime and endTime are not sent, the recent 7 days' data will be returned.
+// The earliest startTime is supported on June 10, 2020
+// Return up to 200 records per request.
+
+type GetC2CTradeHistoryService struct {
+	c              *Client
+	tradeType      *string
+	startTimestamp *uint64
+	endTimestamp   *uint64
+	page           *int
+	recvWindow     *uint64
+	timestamp      *uint64
+}
+
+func (s *GetC2CTradeHistoryService) TradeType(tradeType string) *GetC2CTradeHistoryService {
+	s.tradeType = &tradeType
+	return s
+}
+
+func (s *GetC2CTradeHistoryService) StartTimestamp(startTimestamp uint64) *GetC2CTradeHistoryService {
+	s.startTimestamp = &startTimestamp
+	return s
+}
+
+func (s *GetC2CTradeHistoryService) EndTimestamp(endTimestamp uint64) *GetC2CTradeHistoryService {
+	s.endTimestamp = &endTimestamp
+	return s
+}
+
+func (s *GetC2CTradeHistoryService) Page(page int) *GetC2CTradeHistoryService {
+	s.page = &page
+	return s
+}
+
+func (s *GetC2CTradeHistoryService) RecvWindow(recvWindow uint64) *GetC2CTradeHistoryService {
+	s.recvWindow = &recvWindow
+	return s
+}
+
+func (s *GetC2CTradeHistoryService) Timestamp(timestamp uint64) *GetC2CTradeHistoryService {
+	s.timestamp = &timestamp
+	return s
+}
+
+func (s *GetC2CTradeHistoryService) Do(ctx context.Context) (res *GetC2CTradeHistoryResponse, err error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: getC2CTradeHistory,
+		secType:  secTypeSigned,
+	}
+
+	r.setParam("timestamp", *s.timestamp)
+	if s.tradeType != nil {
+		r.setParam("tradeType", *s.tradeType)
+	}
+	if s.startTimestamp != nil {
+		r.setParam("startTimestamp", *s.startTimestamp)
+	}
+	if s.endTimestamp != nil {
+		r.setParam("endTimestamp", *s.endTimestamp)
+	}
+	if s.page != nil {
+		r.setParam("page", *s.page)
+	}
+	if s.recvWindow != nil {
+		r.setParam("recvWindow", *s.recvWindow)
+	}
+
+	data, err := s.c.callAPI(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	res = &GetC2CTradeHistoryResponse{}
+	err = json.Unmarshal(data, res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+type GetC2CTradeHistoryResponse struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Data    []struct {
+		OrderNumber         string `json:"orderNumber"`
+		AdvNo               string `json:"advNo"`
+		TradeType           string `json:"tradeType"`
+		Asset               string `json:"asset"`
+		Fiat                string `json:"fiat"`
+		FiatSymbol          string `json:"fiatSymbol"`
+		Amount              string `json:"amount"` //amount in crypto
+		TotalPrice          string `json:"totalPrice"`
+		UnitPrice           string `json:"unitPrice"`   //in fiat
+		OrderStatus         string `json:"orderStatus"` // PENDING, TRADING, BUYER_PAYED, DISTRIBUTING, COMPLETED, IN_APPEAL, CANCELLED, CANCELLED_BY_SYSTEM
+		CreateTime          uint64 `json:"createTime"`
+		Commission          string `json:"commission"`
+		CounterPartNickName string `json:"counterPartNickName"`
+		AdvertisementRole   string `json:"advertisementRole"`
+	}
+	Total   int64 `json:"total"`
+	Success bool  `json:"success"`
+}

--- a/c2c_test.go
+++ b/c2c_test.go
@@ -1,0 +1,94 @@
+package binance_connector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type c2cTestSuite struct {
+	baseTestSuite
+}
+
+func TestC2C(t *testing.T) {
+	suite.Run(t, new(c2cTestSuite))
+}
+
+func (s *c2cTestSuite) TestGetC2CTradeHistory() {
+	data := []byte(`
+	{
+		"code": "000000",
+		"message": "success",
+		"data": [
+			{
+				"orderNumber":"20219644646554779648",
+				"advNo": "11218246497340923904",
+				"tradeType": "SELL",  
+				"asset": "BUSD", 
+				"fiat": "CNY",  
+				"fiatSymbol": "￥",
+				"amount": "5000.00000000",
+				"totalPrice": "33400.00000000",
+				"unitPrice": "6.68",
+				"orderStatus": "COMPLETED",
+				"createTime": 1619361369000,
+				"commission": "0",
+				"counterPartNickName": "ab***",
+				"advertisementRole": "TAKER"        
+			}
+		],
+		"total": 1,
+		"success": true 
+	}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	startTimestamp := uint64(1619361369000)
+	endTimestamp := uint64(1619361369000)
+	page := 3
+	tradeType := "SELL"
+	recvWindow := uint64(10000)
+	timestamp := uint64(1619361369000)
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"startTimestamp": startTimestamp,
+			"endTimestamp":   endTimestamp,
+			"page":           page,
+			"tradeType":      tradeType,
+			"recvWindow":     recvWindow,
+			"timestamp":      timestamp,
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	res, err := s.client.NewGetC2CTradeHistoryService().
+		StartTimestamp(startTimestamp).
+		EndTimestamp(endTimestamp).
+		Page(page).
+		TradeType(tradeType).
+		RecvWindow(recvWindow).
+		Timestamp(timestamp).
+		Do(newContext())
+
+	s.r().NoError(err)
+	s.Equal("000000", res.Code)
+	s.Equal("success", res.Message)
+	s.r().Len(res.Data, 1)
+	s.Equal("20219644646554779648", res.Data[0].OrderNumber)
+	s.Equal("11218246497340923904", res.Data[0].AdvNo)
+	s.Equal("SELL", res.Data[0].TradeType)
+	s.Equal("BUSD", res.Data[0].Asset)
+	s.Equal("CNY", res.Data[0].Fiat)
+	s.Equal("￥", res.Data[0].FiatSymbol)
+	s.Equal("5000.00000000", res.Data[0].Amount)
+	s.Equal("33400.00000000", res.Data[0].TotalPrice)
+	s.Equal("6.68", res.Data[0].UnitPrice)
+	s.Equal("COMPLETED", res.Data[0].OrderStatus)
+	s.Equal(uint64(1619361369000), res.Data[0].CreateTime)
+	s.Equal("0", res.Data[0].Commission)
+	s.Equal("ab***", res.Data[0].CounterPartNickName)
+	s.Equal("TAKER", res.Data[0].AdvertisementRole)
+	s.Equal(int64(1), res.Total)
+	s.True(res.Success)
+
+}

--- a/client.go
+++ b/client.go
@@ -775,3 +775,8 @@ func (c *Client) NewGetFiatDepositWithdrawHistoryService() *GetFiatDepositWithdr
 func (c *Client) NewGetFiatPaymentHistoryService() *GetFiatPaymentHistoryService {
 	return &GetFiatPaymentHistoryService{c: c}
 }
+
+// C2C Endpoints:
+func (c *Client) NewGetC2CTradeHistoryService() *GetC2CTradeHistoryService {
+	return &GetC2CTradeHistoryService{c: c}
+}

--- a/examples/c2c/GetC2CTradeHistory/GetC2CTradeHistory.go
+++ b/examples/c2c/GetC2CTradeHistory/GetC2CTradeHistory.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	binance_connector "github.com/binance/binance-connector-go"
+)
+
+func main() {
+	GetC2CTradeHistory()
+}
+
+func GetC2CTradeHistory() {
+	apiKey := "your api key"
+	secretKey := "your secret key"
+	baseURL := "https://api.binance.com"
+
+	client := binance_connector.NewClient(apiKey, secretKey, baseURL)
+
+	// GetC2CTradeHistoryService - /sapi/v1/c2c/orderMatch/listUserOrderHistory
+	getC2CTradeHistory, err := client.NewGetC2CTradeHistoryService().
+		Timestamp(uint64(time.Now().UnixMilli())).
+		Do(context.Background())
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println(binance_connector.PrettyPrint(getC2CTradeHistory))
+}


### PR DESCRIPTION
C2C Product service added by [swagger](https://github.com/binance/binance-api-swagger?tab=readme-ov-file). In [documentation](https://developers.binance.com/docs/c2c/rest-api) not actual information.

Added:

- GetC2CTradeHistoryService
- tests for service
- example
- change README.md