### PR TITLE
Fix ticker 24hr struct for binance response

### DIFF
--- a/market.go
+++ b/market.go
@@ -790,8 +790,8 @@ type Ticker24hrResponse struct {
 	QuoteVolume        string `json:"quoteVolume"`
 	OpenTime           uint64 `json:"openTime"`
 	CloseTime          uint64 `json:"closeTime"`
-	FirstId            uint64 `json:"firstId"`
-	LastId             uint64 `json:"lastId"`
+	FirstId            int64  `json:"firstId"`
+	LastId             int64  `json:"lastId"`
 	Count              uint64 `json:"count"`
 }
 


### PR DESCRIPTION
Fix bug ticker 24hr response struct: [ISSUE-52](https://github.com/binance/binance-connector-go/issues/52)

> When calling NewTicker24hrService().Do(ctx) to fetch all symbol info in order to bypass any possible limits I get the following error:
json: cannot unmarshal number -1 into Go struct field Ticker24hrResponse.firstId of type uint64. I suspect this comes from trying to process a symbol which has no trades yet - and the firstId being uninitiliased.