### PR TITLE
Release Common v1.1.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -172,8 +172,8 @@ jobs:
             PATCH=${VERSION_PARTS[2]}
 
             # Increment patch version
-            NEW_PATCH=$((PATCH + 1))
-            NEW_VERSION="v${MAJOR}.${MINOR}.${NEW_PATCH}"
+            NEW_MINOR=$((MINOR + 1))
+            NEW_VERSION="v${MAJOR}.${NEW_MINOR}.${PATCH}"
           fi
 
           # Set the full tag name

--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -1,8 +1,13 @@
 ### Changelog
 
+## 1.1.0 - 2026-01-13
+
+- Updated `WebsocketStreams` `Subscribe` method to support `int32` format for `id` parameter
+- Support Derivatives Trading Options different WS Streams URL paths.
+
 ## 1.0.1 - 2025-12-17
 
-- Fix `common` tags issue
+- Fixed `common` tags issue
 
 ## 1.0.0 - 2025-12-16
 

--- a/common/common/constants.go
+++ b/common/common/constants.go
@@ -69,7 +69,7 @@ const DerivativesTradingUsdsFuturesWebsocketStreamsTestnetUrl = "wss://stream.bi
 
 // Derivatives Trading Options API URLs
 const DerivativesTradingOptionsRestApiProdUrl = "https://eapi.binance.com"
-const DerivativesTradingOptionsWebsocketStreamsProdUrl = "wss://nbstream.binance.com/eoptions/stream"
+const DerivativesTradingOptionsWebsocketStreamsProdUrl = "wss://fstream.binance.com"
 
 // Derivatives Trading Portfolio Margin API URLs
 const DerivativesTradingPortfolioMarginRestApiProdUrl = "https://papi.binance.com"

--- a/common/common/utils.go
+++ b/common/common/utils.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	randpkg "math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -1001,6 +1002,13 @@ func WsStreamsPlaceholder(stream string, params map[string]string) string {
 // @return A string representing the generated UUID.
 var GenerateUUID = func() string {
 	return uuid.New().String()
+}
+
+// GenerateIntUUID is a function that generates a new random int32 UUID.
+//
+// @return An int32 representing the generated UUID.
+var GenerateIntUUID = func() int32 {
+	return randpkg.Int32()
 }
 
 // Pretty converts a value to its pretty-printed JSON string representation.

--- a/common/common/websocket.go
+++ b/common/common/websocket.go
@@ -1130,7 +1130,7 @@ func (w *WebsocketStreams) Connect(userAgent string) error {
 // @param streams A slice of stream names to subscribe to.
 // @param id A slice of IDs corresponding to each stream. If empty, new UUIDs will be generated.
 // @return An error if any subscription fails, otherwise nil.
-func (w *WebsocketStreams) Subscribe(streams []string, id []string) error {
+func (w *WebsocketStreams) Subscribe(streams []string, id []any, strictInt bool) error {
 	if len(streams) == 0 {
 		return errors.New("no streams to subscribe")
 	}
@@ -1145,7 +1145,13 @@ func (w *WebsocketStreams) Subscribe(streams []string, id []string) error {
 			return err
 		}
 
-		streamID := GenerateUUID()
+		var streamID interface{}
+		if strictInt {
+			streamID = GenerateIntUUID()
+		} else {
+			streamID = GenerateUUID()
+		}
+
 		if len(id) > num {
 			streamID = id[num]
 		}
@@ -1337,9 +1343,9 @@ func (w *WebsocketStreams) CloseWebSocketStreamConnection() error {
 // @param stream The name of the stream to handle.
 // @param id An optional slice of IDs associated with the stream.
 // @return A pointer to the created StreamHandler or an error if subscription fails.
-func CreateStreamHandler[T any](wrapper *StreamHandlerWrapper, stream string, id []string) (*StreamHandler[T], error) {
+func CreateStreamHandler[T any](wrapper *StreamHandlerWrapper, stream string, id []any, strictInt bool) (*StreamHandler[T], error) {
 	if wrapper.WebsocketStreams != nil {
-		if err := wrapper.WebsocketStreams.Subscribe([]string{stream}, id); err != nil {
+		if err := wrapper.WebsocketStreams.Subscribe([]string{stream}, id, strictInt); err != nil {
 			return nil, err
 		}
 	} else if wrapper.WebsocketAPI != nil {


### PR DESCRIPTION
- Updated `WebsocketStreams` `Subscribe` method to support `int32` format for `id` parameter
- Support Derivatives Trading Options different WS Streams URL paths.