### PR TITLE
Release Common v1.2.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -157,7 +157,7 @@ jobs:
 
           if [ -z "$LATEST_TAG" ]; then
             # No tags exist yet, start with v1.0.0
-            NEW_VERSION="v1.1.0"
+            NEW_VERSION="v1.0.0"
           else
             if [ "${{ matrix.client }}" == "common" ]; then
               CURRENT_VERSION=${LATEST_TAG#${{ matrix.client }}/v}

--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Changelog
 
+## 1.2.0 - 2026-01-23
+
+### Added (1)
+
+- Added `Alpha` base url
+
+### Changed (2)
+
+- Updated `PrepareRequest` and `SendRequest` methods to include `signed` boolean parameter to indicate if the request requires signing.
+- Fixed Lock issue in `WebsocketStreams` `Unsubscribe` method by ensuring proper unlocking of mutex after stream removal.
+
 ## 1.1.0 - 2026-01-13
 
 - Updated `WebsocketStreams` `Subscribe` method to support `int32` format for `id` parameter

--- a/common/common/constants.go
+++ b/common/common/constants.go
@@ -39,6 +39,9 @@ const (
 // Algo API URLs
 const AlgoRestApiProdUrl = "https://api.binance.com"
 
+// Alpha API URLs
+const AlphaRestApiProdUrl = "https://www.binance.com"
+
 // C2C API URLs
 const C2CRestApiProdUrl = "https://api.binance.com"
 

--- a/common/common/websocket.go
+++ b/common/common/websocket.go
@@ -1301,6 +1301,8 @@ func (w *WebsocketStreams) Unsubscribe(streams []string) error {
 
 		conn.mu.Lock()
 		delete(conn.StreamCallbackMap, stream)
+		conn.mu.Unlock()
+
 		log.Printf("Unsubscribed from stream %s", stream)
 	}
 

--- a/common/tests/unit/websocket_test.go
+++ b/common/tests/unit/websocket_test.go
@@ -734,10 +734,6 @@ func TestProcessMessage_ResponseMessageHandled(t *testing.T) {
 		},
 	}}
 
-	// doneChan := make(chan []byte, 1)
-	// mockPendingMsgs := sync.Map{}
-	// mockPendingMsgs.Store("0", doneChan)
-
 	conn := &common.WebSocketConnection{
 		Id:                "test-connection",
 		Connected:         common.OPEN,


### PR DESCRIPTION
### Added (1)

- Added `Alpha` base url

### Changed (2)

- Updated `PrepareRequest` and `SendRequest` methods to include `signed` boolean parameter to indicate if the request requires signing.
- Fixed Lock issue in `WebsocketStreams` `Unsubscribe` method by ensuring proper unlocking of mutex after stream removal.
