### PR TITLE
fix: 修复重试等待时间单位错误

### DIFF
--- a/clients/alpha/go.sum
+++ b/clients/alpha/go.sum
@@ -1,5 +1,6 @@
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
+github.com/binance/binance-connector-go/common v1.2.0/go.mod h1:QetR4uDDBwMGHoHJbZvWmyc7P3uJh2Ty6C4COrwpyJY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/common/common/utils.go
+++ b/common/common/utils.go
@@ -449,7 +449,7 @@ func SendRequest[T any](ctx context.Context, path string, method string, queryPa
 		if err != nil {
 			lastErr = err
 			if attempt < retries && ShouldRetryRequest(err, method, retries-attempt, resp) {
-				time.Sleep(time.Duration(backoff*attempt) * time.Second)
+				time.Sleep(time.Duration(backoff*attempt) * time.Millisecond)
 				continue
 			}
 			return &RestApiResponse[T]{}, NewNetworkError(fmt.Sprintf("Network error: %v", err))
@@ -490,7 +490,7 @@ func SendRequest[T any](ctx context.Context, path string, method string, queryPa
 
 		if resp.StatusCode >= 500 && resp.StatusCode <= 504 {
 			if attempt < retries {
-				time.Sleep(time.Duration(backoff*attempt) * time.Second)
+				time.Sleep(time.Duration(backoff*attempt) * time.Millisecond)
 				continue
 			}
 			return &RestApiResponse[T]{}, fmt.Errorf("request failed after %d retries: received status %d", retries, resp.StatusCode)


### PR DESCRIPTION
- 将重试等待时间从秒(S)改为毫秒(ms),否则会sleep足足16分钟

<img width="926" height="326" alt="PixPin_2026-02-04_20-34-55" src="https://github.com/user-attachments/assets/fe33b18b-557e-42b5-962c-b914f0783cca" />


