### PR TITLE
Release Common v2.0.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -172,12 +172,12 @@ jobs:
             # Split into parts
             IFS='.' read -r -a VERSION_PARTS <<< "$CURRENT_VERSION"
             MAJOR=${VERSION_PARTS[0]}
-            MINOR=${VERSION_PARTS[1]}
+            MINOR=0
             PATCH=${VERSION_PARTS[2]}
 
             # Increment patch version
-            NEW_MINOR=$((MINOR + 1))
-            NEW_VERSION="v${MAJOR}.${NEW_MINOR}.${PATCH}"
+            NEW_MAJOR=$((MAJOR + 1))
+            NEW_VERSION="v${NEW_MAJOR}.${MINOR}.${PATCH}"
           fi
 
           # Set the full tag name

--- a/clients/alpha/go.sum
+++ b/clients/alpha/go.sum
@@ -1,6 +1,5 @@
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
-github.com/binance/binance-connector-go/common v1.2.0/go.mod h1:QetR4uDDBwMGHoHJbZvWmyc7P3uJh2Ty6C4COrwpyJY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Changelog
 
+## 2.0.0 - 2026-02-11
+
+### Changed (2)
+
+- Updated `WebSocketCommon` connect method to accept streams parameter for subscribing upon connection.
+- Updated `retry` logic in `utils.go` to use `SleepContext` for better handling of context cancellation during retries.
+
 ## 1.2.0 - 2026-01-23
 
 ### Added (1)

--- a/common/common/utils.go
+++ b/common/common/utils.go
@@ -408,11 +408,11 @@ func ParseRateLimitHeaders(header http.Header) ([]RateLimit, error) {
 	return rateLimits, nil
 }
 
-// SleepContext a sleep that can be cancelled by context.
-// It uses a timer and select to either wait for the specified duration
-// or return immediately if the context is cancelled. This is useful
-// for operations that need to respect context cancellation while
-// waiting, such as retry logic or timeouts in concurrent operations.
+// SleepContext pauses the execution for the specified duration or until the context is done.
+//
+// @param ctx The context to observe for cancellation.
+// @param duration The duration to sleep.
+// @return An error if the context is done before the duration elapses.
 func SleepContext(ctx context.Context, duration time.Duration) error {
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
- Updated `WebSocketCommon` connect method to accept streams parameter for subscribing upon connection.
- Updated `retry` logic in `utils.go` to use `SleepContext` for better handling of context cancellation during retries.